### PR TITLE
Fix Collateral Liquidation

### DIFF
--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -555,7 +555,8 @@ contract TellerV2 is
         _repayLoan(
             _bidId,
             Payment({ principal: duePrincipal, interest: interest }),
-            owedPrincipal + interest
+            owedPrincipal + interest,
+            false
         );
     }
 
@@ -572,7 +573,8 @@ contract TellerV2 is
         _repayLoan(
             _bidId,
             Payment({ principal: owedPrincipal, interest: interest }),
-            owedPrincipal + interest
+            owedPrincipal + interest,
+            false
         );
     }
 
@@ -601,7 +603,8 @@ contract TellerV2 is
         _repayLoan(
             _bidId,
             Payment({ principal: _amount - interest, interest: interest }),
-            owedPrincipal + interest
+            owedPrincipal + interest,
+            false
         );
     }
 
@@ -637,7 +640,8 @@ contract TellerV2 is
         _repayLoan(
             _bidId,
             Payment({ principal: owedPrincipal, interest: interest }),
-            owedPrincipal + interest
+            owedPrincipal + interest,
+            true
         );
 
         bid.state = BidState.LIQUIDATED;
@@ -658,7 +662,8 @@ contract TellerV2 is
     function _repayLoan(
         uint256 _bidId,
         Payment memory _payment,
-        uint256 _owedAmount
+        uint256 _owedAmount,
+        bool _isLiquidation
     ) internal {
         Bid storage bid = bids[_bidId];
         uint256 paymentAmount = _payment.principal + _payment.interest;
@@ -676,8 +681,10 @@ contract TellerV2 is
             // Remove borrower's active bid
             _borrowerBidsActive[bid.borrower].remove(_bidId);
 
-            // If loan is backed by collateral, withdraw and send to borrower
-            collateralManager.withdraw(_bidId);
+            // If loan is is being liquidated and backed by collateral, withdraw and send to borrower
+            if (!_isLiquidation) {
+                collateralManager.withdraw(_bidId);
+            }
 
             emit LoanRepaid(_bidId);
         } else {

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -556,7 +556,7 @@ contract TellerV2 is
             _bidId,
             Payment({ principal: duePrincipal, interest: interest }),
             owedPrincipal + interest,
-            false
+            true
         );
     }
 
@@ -574,7 +574,7 @@ contract TellerV2 is
             _bidId,
             Payment({ principal: owedPrincipal, interest: interest }),
             owedPrincipal + interest,
-            false
+            true
         );
     }
 
@@ -604,7 +604,7 @@ contract TellerV2 is
             _bidId,
             Payment({ principal: _amount - interest, interest: interest }),
             owedPrincipal + interest,
-            false
+            true
         );
     }
 
@@ -641,7 +641,7 @@ contract TellerV2 is
             _bidId,
             Payment({ principal: owedPrincipal, interest: interest }),
             owedPrincipal + interest,
-            true
+            false
         );
 
         bid.state = BidState.LIQUIDATED;
@@ -663,7 +663,7 @@ contract TellerV2 is
         uint256 _bidId,
         Payment memory _payment,
         uint256 _owedAmount,
-        bool _isLiquidation
+        bool _shouldWithdrawCollateral
     ) internal {
         Bid storage bid = bids[_bidId];
         uint256 paymentAmount = _payment.principal + _payment.interest;
@@ -682,7 +682,7 @@ contract TellerV2 is
             _borrowerBidsActive[bid.borrower].remove(_bidId);
 
             // If loan is is being liquidated and backed by collateral, withdraw and send to borrower
-            if (!_isLiquidation) {
+            if (_shouldWithdrawCollateral) {
                 collateralManager.withdraw(_bidId);
             }
 

--- a/packages/contracts/deploy/00_deploy_teller_v2.ts
+++ b/packages/contracts/deploy/00_deploy_teller_v2.ts
@@ -49,7 +49,7 @@ const deployFn: DeployFunction = async (hre) => {
     proxy: {
       proxyContract: 'OpenZeppelinTransparentProxy',
     },
-    skipIfAlreadyDeployed: true,
+    skipIfAlreadyDeployed: false,
     hre,
   })
 


### PR DESCRIPTION
There was a bug where the collateral was being withdrawn twice on a liquidation:
1. when the loan was being repaid
2. when the loan was being liquidation

The simple fix for this is to prevent the collateral from being **withdrawn** during a liquidation repayment