### PR TITLE
 revert if reward claim is 0

### DIFF
--- a/packages/contracts/contracts/MarketLiquidityRewards.sol
+++ b/packages/contracts/contracts/MarketLiquidityRewards.sol
@@ -308,6 +308,8 @@ contract MarketLiquidityRewards is IMarketLiquidityRewards, Initializable {
             amountToReward = allocatedReward.rewardTokenAmount;
         }
 
+        require(amountToReward > 0, "Nothing to claim.");
+
         _decrementAllocatedAmount(_allocationId, amountToReward);
 
         //transfer tokens reward to the msgsender


### PR DESCRIPTION
When claiming a reward, if the amount to claim is zero, the claim will revert. 