### PR TITLE
Issue 176 - fixing frontrun attackability of commitment maxPrincipal

### DIFF
--- a/packages/contracts/contracts/LenderCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder.sol
@@ -61,6 +61,8 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
     mapping(uint256 => EnumerableSetUpgradeable.AddressSet)
         internal commitmentBorrowersList;
 
+    mapping (uint256 => uint256) commitmentPrincipalAllocated; 
+
     /**
      * @notice This event is emitted when a lender's commitment is created.
      * @param lender The address of the lender.
@@ -232,6 +234,26 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
         );
     }
 
+   /* function updateCommitmentExpiration( 
+        uint256 _commitmentId,
+        uint32 _expiration
+    ) public commitmentLender(_commitmentId) {
+
+        Commitment _commitment storage = commitments[_commitmentId];
+
+        _commitment.expiration = _expirationt;
+
+        validateCommitment(commitments[_commitmentId]);
+
+        emit UpdatedCommitment(
+            _commitmentId,
+            _commitment.lender,
+            _commitment.marketId,
+            _commitment.principalTokenAddress,
+            _commitment.maxPrincipal
+        );
+    }*/
+
     /**
      * @notice Updates the borrowers allowed to accept a commitment
      * @param _commitmentId The Id of the commitment to update.
@@ -273,17 +295,7 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
         emit DeletedCommitment(_commitmentId);
     }
 
-    /**
-     * @notice Reduces the commitment amount for a lender to a market.
-     * @param _commitmentId The id of the commitment to modify.
-     * @param _tokenAmountDelta The amount of change in the maxPrincipal.
-     */
-    function _decrementCommitment(
-        uint256 _commitmentId,
-        uint256 _tokenAmountDelta
-    ) internal {
-        commitments[_commitmentId].maxPrincipal -= _tokenAmountDelta;
-    }
+  
 
     /**
      * @notice Accept the commitment to submitBid and acceptBid using the funds
@@ -389,7 +401,10 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
 
         _acceptBid(bidId, commitment.lender);
 
-        _decrementCommitment(_commitmentId, _principalAmount);
+        commitmentPrincipalAllocated[_commitmentId] += _principalAmount;
+
+        require( commitmentPrincipalAllocated[_commitmentId] <= commitment.maxPrincipal, "Exceeds max principal of commitment");
+       // _decrementCommitment(_commitmentId, _principalAmount);
 
         emit ExercisedCommitment(
             _commitmentId,

--- a/packages/contracts/contracts/LenderCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder.sol
@@ -345,6 +345,11 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
             "Invalid loan max duration"
         );
 
+         require(
+            commitmentPrincipalAccepted[bidId] <= commitment.maxPrincipal,
+            "Invalid loan max principal"
+        );
+
         require(
             commitmentBorrowersList[_commitmentId].length() == 0 ||
                 commitmentBorrowersList[_commitmentId].contains(borrower),

--- a/packages/contracts/contracts/LenderCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder.sol
@@ -61,7 +61,7 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
     mapping(uint256 => EnumerableSetUpgradeable.AddressSet)
         internal commitmentBorrowersList;
 
-    mapping (uint256 => uint256) commitmentPrincipalAllocated; 
+    mapping(uint256 => uint256) commitmentPrincipalAllocated;
 
     /**
      * @notice This event is emitted when a lender's commitment is created.
@@ -234,7 +234,7 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
         );
     }
 
-   /* function updateCommitmentExpiration( 
+    /* function updateCommitmentExpiration( 
         uint256 _commitmentId,
         uint32 _expiration
     ) public commitmentLender(_commitmentId) {
@@ -294,8 +294,6 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
         delete commitmentBorrowersList[_commitmentId];
         emit DeletedCommitment(_commitmentId);
     }
-
-  
 
     /**
      * @notice Accept the commitment to submitBid and acceptBid using the funds
@@ -386,10 +384,13 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
             );
         }
 
-
         commitmentPrincipalAllocated[_commitmentId] += _principalAmount;
 
-        require( commitmentPrincipalAllocated[_commitmentId] <= commitment.maxPrincipal, "Exceeds max principal of commitment");
+        require(
+            commitmentPrincipalAllocated[_commitmentId] <=
+                commitment.maxPrincipal,
+            "Exceeds max principal of commitment"
+        );
 
         bidId = _submitBidFromCommitment(
             borrower,
@@ -405,7 +406,7 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
         );
 
         _acceptBid(bidId, commitment.lender);
- 
+
         emit ExercisedCommitment(
             _commitmentId,
             borrower,

--- a/packages/contracts/contracts/LenderCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder.sol
@@ -62,7 +62,7 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
     mapping(uint256 => EnumerableSetUpgradeable.AddressSet)
         internal commitmentBorrowersList;
 
-    mapping(uint256 => uint256) commitmentPrincipalAllocated;
+    mapping(uint256 => uint256) commitmentPrincipalAccepted;
 
     /**
      * @notice This event is emitted when a lender's commitment is created.
@@ -234,7 +234,6 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
             _commitment.maxPrincipal
         );
     }
- 
 
     /**
      * @notice Updates the borrowers allowed to accept a commitment
@@ -395,10 +394,10 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
             );
         }
 
-        commitmentPrincipalAllocated[_commitmentId] += _principalAmount;
+        commitmentPrincipalAccepted[_commitmentId] += _principalAmount;
 
         require(
-            commitmentPrincipalAllocated[_commitmentId] <=
+            commitmentPrincipalAccepted[_commitmentId] <=
                 commitment.maxPrincipal,
             "Exceeds max principal of commitment"
         );

--- a/packages/contracts/contracts/LenderCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder.sol
@@ -386,6 +386,11 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
             );
         }
 
+
+        commitmentPrincipalAllocated[_commitmentId] += _principalAmount;
+
+        require( commitmentPrincipalAllocated[_commitmentId] <= commitment.maxPrincipal, "Exceeds max principal of commitment");
+
         bidId = _submitBidFromCommitment(
             borrower,
             commitment.marketId,
@@ -400,12 +405,7 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
         );
 
         _acceptBid(bidId, commitment.lender);
-
-        commitmentPrincipalAllocated[_commitmentId] += _principalAmount;
-
-        require( commitmentPrincipalAllocated[_commitmentId] <= commitment.maxPrincipal, "Exceeds max principal of commitment");
-       // _decrementCommitment(_commitmentId, _principalAmount);
-
+ 
         emit ExercisedCommitment(
             _commitmentId,
             borrower,

--- a/packages/contracts/contracts/LenderCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder.sol
@@ -234,26 +234,7 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
             _commitment.maxPrincipal
         );
     }
-
-    /* function updateCommitmentExpiration( 
-        uint256 _commitmentId,
-        uint32 _expiration
-    ) public commitmentLender(_commitmentId) {
-
-        Commitment _commitment storage = commitments[_commitmentId];
-
-        _commitment.expiration = _expirationt;
-
-        validateCommitment(commitments[_commitmentId]);
-
-        emit UpdatedCommitment(
-            _commitmentId,
-            _commitment.lender,
-            _commitment.marketId,
-            _commitment.principalTokenAddress,
-            _commitment.maxPrincipal
-        );
-    }*/
+ 
 
     /**
      * @notice Updates the borrowers allowed to accept a commitment

--- a/packages/contracts/contracts/LenderCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder.sol
@@ -62,7 +62,7 @@ contract LenderCommitmentForwarder is TellerV2MarketForwarder {
     mapping(uint256 => EnumerableSetUpgradeable.AddressSet)
         internal commitmentBorrowersList;
 
-    mapping(uint256 => uint256) commitmentPrincipalAccepted;
+    mapping(uint256 => uint256) public commitmentPrincipalAccepted;
 
     /**
      * @notice This event is emitted when a lender's commitment is created.

--- a/packages/contracts/tests/CollateralManager_Test.sol
+++ b/packages/contracts/tests/CollateralManager_Test.sol
@@ -59,7 +59,6 @@ contract CollateralManager_Test is Testable {
     );
 
     function setUp() public {
-    
         // Deploy beacon contract with implementation
         UpgradeableBeacon escrowBeacon = new UpgradeableBeacon(
             address(escrowImplementation)
@@ -73,7 +72,6 @@ contract CollateralManager_Test is Testable {
         borrower = new User();
         lender = new User();
         liquidator = new User();
- 
 
         //  uint256 borrowerBalance = 50000;
         //   payable(address(borrower)).transfer(borrowerBalance);
@@ -93,7 +91,6 @@ contract CollateralManager_Test is Testable {
 
         CollateralManager_Override tempCManager = new CollateralManager_Override();
         tempCManager.initialize(address(eBeacon), address(tellerV2Mock));
- 
 
         address managerTellerV2 = address(tempCManager.tellerV2());
         assertEq(

--- a/packages/contracts/tests/LenderCommitmentForwarder_Combined_Test.sol
+++ b/packages/contracts/tests/LenderCommitmentForwarder_Combined_Test.sol
@@ -211,11 +211,7 @@ contract LenderCommitmentForwarder_Test is Testable, LenderCommitmentForwarder {
             "Expect accept bid called after exercise"
         );
 
-        assertEq(
-            commitment.maxPrincipal == 100,
-            true,
-            "Commitment max principal was not decremented"
-        );
+  
 
         bidId = borrower._acceptCommitment(
             commitmentId,
@@ -227,11 +223,10 @@ contract LenderCommitmentForwarder_Test is Testable, LenderCommitmentForwarder {
             maxLoanDuration
         );
 
-        assertEq(commitment.maxPrincipal == 0, true, "commitment not accepted");
+         
 
-        bool acceptCommitTwiceFails;
-
-        try
+         vm.expectRevert();
+        
             borrower._acceptCommitment(
                 commitmentId,
                 100, //principalAmount
@@ -240,16 +235,10 @@ contract LenderCommitmentForwarder_Test is Testable, LenderCommitmentForwarder {
                 address(collateralToken),
                 minInterestRate,
                 maxLoanDuration
-            )
-        {} catch {
-            acceptCommitTwiceFails = true;
-        }
+            );
+      
 
-        assertEq(
-            acceptCommitTwiceFails,
-            true,
-            "Should fail when accepting commit twice"
-        );
+       
     }
 
     function test_acceptCommitmentWithBorrowersArray_valid() public {
@@ -423,25 +412,7 @@ contract LenderCommitmentForwarder_Test is Testable, LenderCommitmentForwarder {
         );
     }
 
-    function decrementCommitment_before() public {}
-
-    function test_decrementCommitment() public {
-        uint256 commitmentId = 0;
-        uint256 _decrementAmount = 22;
-
-        Commitment storage commitment = _createCommitment(
-            CommitmentCollateralType.ERC20,
-            1000e6
-        );
-
-        _decrementCommitment(commitmentId, _decrementAmount);
-
-        assertEq(
-            commitment.maxPrincipal == maxAmount - _decrementAmount,
-            true,
-            "Commitment max principal was not decremented"
-        );
-    }
+   
 
     /**
      *             collateral token = WETH (10**18)

--- a/packages/contracts/tests/LenderCommitmentForwarder_Combined_Test.sol
+++ b/packages/contracts/tests/LenderCommitmentForwarder_Combined_Test.sol
@@ -211,8 +211,6 @@ contract LenderCommitmentForwarder_Test is Testable, LenderCommitmentForwarder {
             "Expect accept bid called after exercise"
         );
 
-  
-
         bidId = borrower._acceptCommitment(
             commitmentId,
             100, //principalAmount
@@ -223,22 +221,17 @@ contract LenderCommitmentForwarder_Test is Testable, LenderCommitmentForwarder {
             maxLoanDuration
         );
 
-         
+        vm.expectRevert();
 
-         vm.expectRevert();
-        
-            borrower._acceptCommitment(
-                commitmentId,
-                100, //principalAmount
-                100, //collateralAmount
-                0, //collateralTokenId
-                address(collateralToken),
-                minInterestRate,
-                maxLoanDuration
-            );
-      
-
-       
+        borrower._acceptCommitment(
+            commitmentId,
+            100, //principalAmount
+            100, //collateralAmount
+            0, //collateralTokenId
+            address(collateralToken),
+            minInterestRate,
+            maxLoanDuration
+        );
     }
 
     function test_acceptCommitmentWithBorrowersArray_valid() public {
@@ -411,8 +404,6 @@ contract LenderCommitmentForwarder_Test is Testable, LenderCommitmentForwarder {
             "Should fail to accept commitment with invalid amount for ERC721"
         );
     }
-
-   
 
     /**
      *             collateral token = WETH (10**18)

--- a/packages/contracts/tests/LenderCommitmentForwarder_Override.sol
+++ b/packages/contracts/tests/LenderCommitmentForwarder_Override.sol
@@ -44,7 +44,7 @@ contract LenderCommitmentForwarder_Override is LenderCommitmentForwarder {
     {
         return commitments[_commitmentId].marketId;
     }
- 
+
     function _getEscrowCollateralTypeSuper(CommitmentCollateralType _type)
         public
         returns (CollateralType)

--- a/packages/contracts/tests/LenderCommitmentForwarder_Override.sol
+++ b/packages/contracts/tests/LenderCommitmentForwarder_Override.sol
@@ -44,14 +44,7 @@ contract LenderCommitmentForwarder_Override is LenderCommitmentForwarder {
     {
         return commitments[_commitmentId].marketId;
     }
-
-    function _decrementCommitmentSuper(
-        uint256 _commitmentId,
-        uint256 _tokenAmountDelta
-    ) public {
-        super._decrementCommitment(_commitmentId, _tokenAmountDelta);
-    }
-
+ 
     function _getEscrowCollateralTypeSuper(CommitmentCollateralType _type)
         public
         returns (CollateralType)

--- a/packages/contracts/tests/LenderCommitmentForwarder_Test.sol
+++ b/packages/contracts/tests/LenderCommitmentForwarder_Test.sol
@@ -431,8 +431,6 @@ contract LenderCommitmentForwarder_Test is Testable {
         lenderCommitmentForwarder.deleteCommitment(0);
     }
 
-    
-
     function test_validateCommitment() public {
         LenderCommitmentForwarder.Commitment
             memory c = LenderCommitmentForwarder.Commitment({

--- a/packages/contracts/tests/LenderCommitmentForwarder_Test.sol
+++ b/packages/contracts/tests/LenderCommitmentForwarder_Test.sol
@@ -431,34 +431,7 @@ contract LenderCommitmentForwarder_Test is Testable {
         lenderCommitmentForwarder.deleteCommitment(0);
     }
 
-    function test_decrementCommitment() public {
-        LenderCommitmentForwarder.Commitment
-            memory c = LenderCommitmentForwarder.Commitment({
-                maxPrincipal: maxPrincipal,
-                expiration: expiration,
-                maxDuration: maxDuration,
-                minInterestRate: minInterestRate,
-                collateralTokenAddress: address(collateralToken),
-                collateralTokenId: collateralTokenId,
-                maxPrincipalPerCollateralAmount: maxPrincipalPerCollateralAmount,
-                collateralTokenType: collateralTokenType,
-                lender: address(lender),
-                marketId: marketId,
-                principalTokenAddress: address(principalToken)
-            });
-
-        uint256 commitmentId = 0;
-
-        lenderCommitmentForwarder.setCommitment(commitmentId, c);
-
-        lenderCommitmentForwarder._decrementCommitmentSuper(commitmentId, 100);
-
-        assertEq(
-            lenderCommitmentForwarder.getCommitmentMaxPrincipal(commitmentId),
-            maxPrincipal - 100,
-            "Max principal not decremented"
-        );
-    }
+    
 
     function test_validateCommitment() public {
         LenderCommitmentForwarder.Commitment
@@ -660,8 +633,8 @@ contract LenderCommitmentForwarder_Test is Testable {
 
         assertEq(
             lenderCommitmentForwarder.getCommitmentMaxPrincipal(commitmentId),
-            principalAmount - maxPrincipal,
-            "Max principal not decremented"
+            maxPrincipal,
+            "Max principal changed"
         );
     }
 


### PR DESCRIPTION
Adds a mapping to keep track of commitment amount that has been used by borrowers 

This will require a minor migration strategy review 