### PR TITLE
Issue 250 - Prevents updating CommitCollateral in an unintended way

### DIFF
--- a/packages/contracts/contracts/CollateralManager.sol
+++ b/packages/contracts/contracts/CollateralManager.sol
@@ -428,8 +428,7 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
         Collateral memory _collateralInfo
     ) internal virtual {
         CollateralInfo storage collateral = _bidCollaterals[_bidId];
-      
-      
+
         require(
             !collateral.collateralAddresses.contains(
                 _collateralInfo._collateralAddress
@@ -441,13 +440,12 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
                 _collateralInfo._amount == 1,
             "ERC721 collateral must have amount of 1"
         );
-      
-      
+
         collateral.collateralAddresses.add(_collateralInfo._collateralAddress);
         collateral.collateralInfo[
             _collateralInfo._collateralAddress
         ] = _collateralInfo;
-        emit CollateralCommitted( 
+        emit CollateralCommitted(
             _bidId,
             _collateralInfo._collateralType,
             _collateralInfo._collateralAddress,

--- a/packages/contracts/contracts/CollateralManager.sol
+++ b/packages/contracts/contracts/CollateralManager.sol
@@ -428,11 +428,26 @@ contract CollateralManager is OwnableUpgradeable, ICollateralManager {
         Collateral memory _collateralInfo
     ) internal virtual {
         CollateralInfo storage collateral = _bidCollaterals[_bidId];
+      
+      
+        require(
+            !collateral.collateralAddresses.contains(
+                _collateralInfo._collateralAddress
+            ),
+            "Cannot commit multiple collateral with the same address"
+        );
+        require(
+            _collateralInfo._collateralType != CollateralType.ERC721 ||
+                _collateralInfo._amount == 1,
+            "ERC721 collateral must have amount of 1"
+        );
+      
+      
         collateral.collateralAddresses.add(_collateralInfo._collateralAddress);
         collateral.collateralInfo[
             _collateralInfo._collateralAddress
         ] = _collateralInfo;
-        emit CollateralCommitted(
+        emit CollateralCommitted( 
             _bidId,
             _collateralInfo._collateralType,
             _collateralInfo._collateralAddress,

--- a/packages/contracts/tests/CollateralManager_Test.sol
+++ b/packages/contracts/tests/CollateralManager_Test.sol
@@ -59,7 +59,6 @@ contract CollateralManager_Test is Testable {
     );
 
     function setUp() public {
-    
         // Deploy beacon contract with implementation
         UpgradeableBeacon escrowBeacon = new UpgradeableBeacon(
             address(escrowImplementation)
@@ -73,7 +72,6 @@ contract CollateralManager_Test is Testable {
         borrower = new User();
         lender = new User();
         liquidator = new User();
- 
 
         //  uint256 borrowerBalance = 50000;
         //   payable(address(borrower)).transfer(borrowerBalance);
@@ -93,7 +91,6 @@ contract CollateralManager_Test is Testable {
 
         CollateralManager_Override tempCManager = new CollateralManager_Override();
         tempCManager.initialize(address(eBeacon), address(tellerV2Mock));
- 
 
         address managerTellerV2 = address(tempCManager.tellerV2());
         assertEq(
@@ -635,8 +632,6 @@ contract CollateralManager_Test is Testable {
         vm.expectRevert("ERC721 collateral must have amount of 1");
         collateralManager._commitCollateralSuper(bidId, collateralInfo);
     }
-
-     
 
     function test_withdraw_internal() public {
         uint256 bidId = 0;

--- a/packages/contracts/tests/CollateralManager_Test.sol
+++ b/packages/contracts/tests/CollateralManager_Test.sol
@@ -598,6 +598,46 @@ contract CollateralManager_Test is Testable {
         );
     }
 
+    function test_commit_collateral_address_multiple_times() public {
+        uint256 bidId = 0;
+        address recipient = address(borrower);
+
+        wethMock.transfer(address(escrowImplementation), 1000);
+
+        Collateral memory collateralInfo = Collateral({
+            _collateralType: CollateralType.ERC721,
+            _amount: 1,
+            _tokenId: 2,
+            _collateralAddress: address(wethMock)
+        });
+
+        collateralManager._commitCollateralSuper(bidId, collateralInfo);
+
+        vm.expectRevert(
+            "Cannot commit multiple collateral with the same address"
+        );
+        collateralManager._commitCollateralSuper(bidId, collateralInfo);
+    }
+
+    function test_commit_collateral_ERC721_amount_1() public {
+        uint256 bidId = 0;
+        address recipient = address(borrower);
+
+        wethMock.transfer(address(escrowImplementation), 1000);
+
+        Collateral memory collateralInfo = Collateral({
+            _collateralType: CollateralType.ERC721,
+            _amount: 1000,
+            _tokenId: 2,
+            _collateralAddress: address(wethMock)
+        });
+
+        vm.expectRevert("ERC721 collateral must have amount of 1");
+        collateralManager._commitCollateralSuper(bidId, collateralInfo);
+    }
+
+     
+
     function test_withdraw_internal() public {
         uint256 bidId = 0;
         address recipient = address(borrower);

--- a/packages/contracts/tests/TellerV2/TellerV2_Test.sol
+++ b/packages/contracts/tests/TellerV2/TellerV2_Test.sol
@@ -206,7 +206,6 @@ contract TellerV2_Test is Testable {
         );
     }
 
-
     function test_commit_collateral_frontrun_exploit() public {
         // The original borrower balance for the DAI principal and WETH collateral
         assertEq(daiMock.balanceOf(address(borrower)), 50000);
@@ -219,7 +218,8 @@ contract TellerV2_Test is Testable {
         uint256 bidId = submitCollateralBid();
 
         // The original bid is for 10 WETH
-        uint256 originalCollateralAmount = collateralManager.getCollateralAmount(bidId, address(wethMock));
+        uint256 originalCollateralAmount = collateralManager
+            .getCollateralAmount(bidId, address(wethMock));
         assertEq(originalCollateralAmount, 10);
 
         // This is just to illustrate that some time passes (but it is irrelevant)
@@ -246,7 +246,7 @@ contract TellerV2_Test is Testable {
         collateralManager.commitCollateral(bidId, info);
 
         // The lender is now victim to the frontrunning and accepts the malicious bid
-      /*  acceptBid(bidId);
+        /*  acceptBid(bidId);
 
         // The borrower now has the expected 95 DAI from the loan (5 DAI are gone in fees)
         // But he only provided 1 WETH as collateral instead of the original amount of 10 WETH
@@ -256,7 +256,6 @@ contract TellerV2_Test is Testable {
         // The lender lost his principal of 100 DAI, as the loan is only collateralized by 1 WETH instead of 10 WETH
         assertEq(daiMock.balanceOf(address(lender)), 499900);*/
     }
-
 }
 
 contract TellerV2User is User {

--- a/packages/contracts/tests/TellerV2/TellerV2_Test.sol
+++ b/packages/contracts/tests/TellerV2/TellerV2_Test.sol
@@ -205,6 +205,58 @@ contract TellerV2_Test is Testable {
             "Collateral was not sent to borrower after repayment"
         );
     }
+
+
+    function test_commit_collateral_frontrun_exploit() public {
+        // The original borrower balance for the DAI principal and WETH collateral
+        assertEq(daiMock.balanceOf(address(borrower)), 50000);
+        assertEq(wethMock.balanceOf(address(borrower)), 50000);
+
+        // The original lender balance for the DAI principal -> This will be stolen
+        assertEq(daiMock.balanceOf(address(lender)), 500000);
+
+        // Submit bid as borrower
+        uint256 bidId = submitCollateralBid();
+
+        // The original bid is for 10 WETH
+        uint256 originalCollateralAmount = collateralManager.getCollateralAmount(bidId, address(wethMock));
+        assertEq(originalCollateralAmount, 10);
+
+        // This is just to illustrate that some time passes (but it is irrelevant)
+        vm.warp(100);
+
+        // A potential lender finds the bid attractive and decides to accept the bid
+
+        // The attack begins here
+        // The malicious borrower sees the transaction in the mempool and frontruns it
+
+        // The borrower prepares the malicious bid lowering the amount to the minimum possible
+        Collateral memory info;
+        info._amount = 1; // @audit minimum amount
+        info._tokenId = 0;
+        info._collateralAddress = address(wethMock);
+        info._collateralType = CollateralType.ERC20;
+
+        Collateral[] memory collateralInfo = new Collateral[](1);
+        collateralInfo[0] = info;
+
+        // The malicious borrower performs the attack by frontrunning the tx and updating the bid collateral amount
+        vm.prank(address(borrower));
+        vm.expectRevert();
+        collateralManager.commitCollateral(bidId, info);
+
+        // The lender is now victim to the frontrunning and accepts the malicious bid
+      /*  acceptBid(bidId);
+
+        // The borrower now has the expected 95 DAI from the loan (5 DAI are gone in fees)
+        // But he only provided 1 WETH as collateral instead of the original amount of 10 WETH
+        assertEq(daiMock.balanceOf(address(borrower)), 50095);
+        assertEq(wethMock.balanceOf(address(borrower)), 49999); // @audit only provided 1 WETH
+
+        // The lender lost his principal of 100 DAI, as the loan is only collateralized by 1 WETH instead of 10 WETH
+        assertEq(daiMock.balanceOf(address(lender)), 499900);*/
+    }
+
 }
 
 contract TellerV2User is User {


### PR DESCRIPTION
Prevents from updating CommitCollateral in an unintended way and also prevents the same collateral address from being commited to a loan more than once . 