### PR TITLE
Issue 225 - Alternative Fix - Add a function to repay without collateral withdraw 

### DIFF
--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -620,6 +620,29 @@ contract TellerV2 is
         );
     }
 
+
+      /**
+     * @notice Function for users to repay an active loan in full.
+     * @param _bidId The id of the loan to make the payment towards.
+     */
+    function repayLoanFullWithoutCollateralWithdraw(uint256 _bidId)
+        external
+        acceptedLoan(_bidId, "repayLoan")
+    {
+        (uint256 owedPrincipal, , uint256 interest) = V2Calculations
+            .calculateAmountOwed(
+                bids[_bidId],
+                block.timestamp,
+                bidPaymentCycleType[_bidId]
+            );
+        _repayLoan(
+            _bidId,
+            Payment({ principal: owedPrincipal, interest: interest }),
+            owedPrincipal + interest,
+            false
+        );
+    }
+
     // function that the borrower (ideally) sends to repay the loan
     /**
      * @notice Function for users to make a payment towards an active loan.

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -606,10 +606,8 @@ contract TellerV2 is
         external
         acceptedLoan(_bidId, "repayLoan")
     {
-       
         _repayLoanFull(_bidId, true);
     }
- 
 
     // function that the borrower (ideally) sends to repay the loan
     /**
@@ -621,13 +619,10 @@ contract TellerV2 is
         external
         acceptedLoan(_bidId, "repayLoan")
     {
-       
-
-        _repayLoanAtleastMinimum(_bidId,_amount,true);
+        _repayLoanAtleastMinimum(_bidId, _amount, true);
     }
 
-
-     /**
+    /**
      * @notice Function for users to repay an active loan in full.
      * @param _bidId The id of the loan to make the payment towards.
      */
@@ -635,25 +630,18 @@ contract TellerV2 is
         external
         acceptedLoan(_bidId, "repayLoan")
     {
-     
-        _repayLoanFull(_bidId,false);
+        _repayLoanFull(_bidId, false);
     }
-
-   
 
     function repayLoanWithoutCollateralWithdraw(uint256 _bidId, uint256 _amount)
         external
         acceptedLoan(_bidId, "repayLoan")
     {
-       _repayLoanAtleastMinimum(_bidId,_amount,false);
+        _repayLoanAtleastMinimum(_bidId, _amount, false);
     }
 
-
-
-    function _repayLoanFull(uint256 _bidId, bool withdrawCollateral)
-        internal
-    {
-         (uint256 owedPrincipal, , uint256 interest) = V2Calculations
+    function _repayLoanFull(uint256 _bidId, bool withdrawCollateral) internal {
+        (uint256 owedPrincipal, , uint256 interest) = V2Calculations
             .calculateAmountOwed(
                 bids[_bidId],
                 block.timestamp,
@@ -667,11 +655,12 @@ contract TellerV2 is
         );
     }
 
-
-    function _repayLoanAtleastMinimum(uint256 _bidId, uint256 _amount, bool withdrawCollateral )
-        internal 
-    {
-    (
+    function _repayLoanAtleastMinimum(
+        uint256 _bidId,
+        uint256 _amount,
+        bool withdrawCollateral
+    ) internal {
+        (
             uint256 owedPrincipal,
             uint256 duePrincipal,
             uint256 interest
@@ -694,7 +683,6 @@ contract TellerV2 is
             withdrawCollateral
         );
     }
-
 
     /**
      * @notice Lets the DAO/owner of the protocol implement an emergency stop mechanism.

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -621,27 +621,7 @@ contract TellerV2 is
     }
 
 
-      /**
-     * @notice Function for users to repay an active loan in full.
-     * @param _bidId The id of the loan to make the payment towards.
-     */
-    function repayLoanFullWithoutCollateralWithdraw(uint256 _bidId)
-        external
-        acceptedLoan(_bidId, "repayLoan")
-    {
-        (uint256 owedPrincipal, , uint256 interest) = V2Calculations
-            .calculateAmountOwed(
-                bids[_bidId],
-                block.timestamp,
-                bidPaymentCycleType[_bidId]
-            );
-        _repayLoan(
-            _bidId,
-            Payment({ principal: owedPrincipal, interest: interest }),
-            owedPrincipal + interest,
-            false
-        );
-    }
+   
 
     // function that the borrower (ideally) sends to repay the loan
     /**
@@ -676,6 +656,58 @@ contract TellerV2 is
             true
         );
     }
+
+
+     /**
+     * @notice Function for users to repay an active loan in full.
+     * @param _bidId The id of the loan to make the payment towards.
+     */
+    function repayLoanFullWithoutCollateralWithdraw(uint256 _bidId)
+        external
+        acceptedLoan(_bidId, "repayLoan")
+    {
+        (uint256 owedPrincipal, , uint256 interest) = V2Calculations
+            .calculateAmountOwed(
+                bids[_bidId],
+                block.timestamp,
+                bidPaymentCycleType[_bidId]
+            );
+        _repayLoan(
+            _bidId,
+            Payment({ principal: owedPrincipal, interest: interest }),
+            owedPrincipal + interest,
+            false
+        );
+    }
+
+      function repayLoanWithoutCollateralWithdraw(uint256 _bidId, uint256 _amount)
+        external
+        acceptedLoan(_bidId, "repayLoan")
+    {
+        (
+            uint256 owedPrincipal,
+            uint256 duePrincipal,
+            uint256 interest
+        ) = V2Calculations.calculateAmountOwed(
+                bids[_bidId],
+                block.timestamp,
+                bidPaymentCycleType[_bidId]
+            );
+        uint256 minimumOwed = duePrincipal + interest;
+
+        // If amount is less than minimumOwed, we revert
+        if (_amount < minimumOwed) {
+            revert PaymentNotMinimum(_bidId, _amount, minimumOwed);
+        }
+
+        _repayLoan(
+            _bidId,
+            Payment({ principal: _amount - interest, interest: interest }),
+            owedPrincipal + interest,
+            false
+        );
+    }
+
 
     /**
      * @notice Lets the DAO/owner of the protocol implement an emergency stop mechanism.

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -606,22 +606,10 @@ contract TellerV2 is
         external
         acceptedLoan(_bidId, "repayLoan")
     {
-        (uint256 owedPrincipal, , uint256 interest) = V2Calculations
-            .calculateAmountOwed(
-                bids[_bidId],
-                block.timestamp,
-                bidPaymentCycleType[_bidId]
-            );
-        _repayLoan(
-            _bidId,
-            Payment({ principal: owedPrincipal, interest: interest }),
-            owedPrincipal + interest,
-            true
-        );
+       
+        _repayLoanFull(_bidId, true);
     }
-
-
-   
+ 
 
     // function that the borrower (ideally) sends to repay the loan
     /**
@@ -633,28 +621,9 @@ contract TellerV2 is
         external
         acceptedLoan(_bidId, "repayLoan")
     {
-        (
-            uint256 owedPrincipal,
-            uint256 duePrincipal,
-            uint256 interest
-        ) = V2Calculations.calculateAmountOwed(
-                bids[_bidId],
-                block.timestamp,
-                bidPaymentCycleType[_bidId]
-            );
-        uint256 minimumOwed = duePrincipal + interest;
+       
 
-        // If amount is less than minimumOwed, we revert
-        if (_amount < minimumOwed) {
-            revert PaymentNotMinimum(_bidId, _amount, minimumOwed);
-        }
-
-        _repayLoan(
-            _bidId,
-            Payment({ principal: _amount - interest, interest: interest }),
-            owedPrincipal + interest,
-            true
-        );
+        _repayLoanAtleastMinimum(_bidId,_amount,true);
     }
 
 
@@ -666,7 +635,25 @@ contract TellerV2 is
         external
         acceptedLoan(_bidId, "repayLoan")
     {
-        (uint256 owedPrincipal, , uint256 interest) = V2Calculations
+     
+        _repayLoanFull(_bidId,false);
+    }
+
+   
+
+    function repayLoanWithoutCollateralWithdraw(uint256 _bidId, uint256 _amount)
+        external
+        acceptedLoan(_bidId, "repayLoan")
+    {
+       _repayLoanAtleastMinimum(_bidId,_amount,false);
+    }
+
+
+
+    function _repayLoanFull(uint256 _bidId, bool withdrawCollateral)
+        internal
+    {
+         (uint256 owedPrincipal, , uint256 interest) = V2Calculations
             .calculateAmountOwed(
                 bids[_bidId],
                 block.timestamp,
@@ -676,15 +663,15 @@ contract TellerV2 is
             _bidId,
             Payment({ principal: owedPrincipal, interest: interest }),
             owedPrincipal + interest,
-            false
+            withdrawCollateral
         );
     }
 
-      function repayLoanWithoutCollateralWithdraw(uint256 _bidId, uint256 _amount)
-        external
-        acceptedLoan(_bidId, "repayLoan")
+
+    function _repayLoanAtleastMinimum(uint256 _bidId, uint256 _amount, bool withdrawCollateral )
+        internal 
     {
-        (
+    (
             uint256 owedPrincipal,
             uint256 duePrincipal,
             uint256 interest
@@ -704,7 +691,7 @@ contract TellerV2 is
             _bidId,
             Payment({ principal: _amount - interest, interest: interest }),
             owedPrincipal + interest,
-            false
+            withdrawCollateral
         );
     }
 

--- a/packages/contracts/tests/CollateralManager_Test.sol
+++ b/packages/contracts/tests/CollateralManager_Test.sol
@@ -59,7 +59,6 @@ contract CollateralManager_Test is Testable {
     );
 
     function setUp() public {
-    
         // Deploy beacon contract with implementation
         UpgradeableBeacon escrowBeacon = new UpgradeableBeacon(
             address(escrowImplementation)
@@ -73,7 +72,6 @@ contract CollateralManager_Test is Testable {
         borrower = new User();
         lender = new User();
         liquidator = new User();
- 
 
         //  uint256 borrowerBalance = 50000;
         //   payable(address(borrower)).transfer(borrowerBalance);
@@ -93,7 +91,6 @@ contract CollateralManager_Test is Testable {
 
         CollateralManager_Override tempCManager = new CollateralManager_Override();
         tempCManager.initialize(address(eBeacon), address(tellerV2Mock));
- 
 
         address managerTellerV2 = address(tempCManager.tellerV2());
         assertEq(


### PR DESCRIPTION
The original fix to issue 255 split repayment and collateral withdraw into 2 separate fns.  This fix is less invasive to the user flow and instead just adds functions to allow for repayment without collateral withdraw included.  That way, users can still repay on their loans even if there is an issue with collateral transferrance. 