### PR TITLE
Reduce contract size 

### DIFF
--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -872,27 +872,6 @@ contract TellerV2 is
     }
 
     /**
-     * @notice Calculates the total amount owed for a bid.
-     * @param _bidId The id of the loan bid to calculate the owed amount for.
-     */
-  /*  function calculateAmountOwed(uint256 _bidId)
-        public
-        view
-        returns (Payment memory owed)
-    {
-        if (bids[_bidId].state != BidState.ACCEPTED) return owed;
-
-        (uint256 owedPrincipal, , uint256 interest) = V2Calculations
-            .calculateAmountOwed(
-                bids[_bidId],
-                block.timestamp,
-                bidPaymentCycleType[_bidId]
-            );
-        owed.principal = owedPrincipal;
-        owed.interest = interest;
-    }*/
-
-    /**
      * @notice Calculates the total amount owed for a loan bid at a specific timestamp.
      * @param _bidId The id of the loan bid to calculate the owed amount for.
      * @param _timestamp The timestamp at which to calculate the loan owed amount at.
@@ -913,27 +892,6 @@ contract TellerV2 is
         owed.principal = owedPrincipal;
         owed.interest = interest;
     }
-
-    /**
-     * @notice Calculates the minimum payment amount due for a loan.
-     * @param _bidId The id of the loan bid to get the payment amount for.
-     */
-   /* function calculateAmountDue(uint256 _bidId)
-        public
-        view
-        returns (Payment memory due)
-    {
-        if (bids[_bidId].state != BidState.ACCEPTED) return due;
-
-        (, uint256 duePrincipal, uint256 interest) = V2Calculations
-            .calculateAmountOwed(
-                bids[_bidId],
-                block.timestamp,
-                bidPaymentCycleType[_bidId]
-            );
-        due.principal = duePrincipal;
-        due.interest = interest;
-    }*/
 
     /**
      * @notice Calculates the minimum payment amount due for a loan at a specific timestamp.
@@ -969,12 +927,13 @@ contract TellerV2 is
         Bid storage bid = bids[_bidId];
         if (bids[_bidId].state != BidState.ACCEPTED) return dueDate_;
 
-        return V2Calculations.calculateNextDueDate(
-            bid,
-            lastRepaidTimestamp(_bidId),
-            bidPaymentCycleType[_bidId]
+        return
+            V2Calculations.calculateNextDueDate(
+                bid,
+                lastRepaidTimestamp(_bidId),
+                bidPaymentCycleType[_bidId]
             );
-    }   
+    }
 
     /**
      * @notice Checks to see if a borrower is delinquent.

--- a/packages/contracts/contracts/TellerV2.sol
+++ b/packages/contracts/contracts/TellerV2.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import "./ProtocolFee.sol";
 import "./TellerV2Storage.sol";
 import "./TellerV2Context.sol";
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
@@ -51,7 +51,7 @@ contract TellerV2 is
     TellerV2Context
 {
     using Address for address;
-    using SafeERC20 for ERC20;
+    using SafeERC20 for IERC20;
     using NumbersLib for uint256;
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.UintSet;
@@ -374,7 +374,7 @@ contract TellerV2 is
         bid.borrower = sender;
         bid.receiver = _receiver != address(0) ? _receiver : bid.borrower;
         bid.marketplaceId = _marketplaceId;
-        bid.loanDetails.lendingToken = ERC20(_lendingToken);
+        bid.loanDetails.lendingToken = IERC20(_lendingToken);
         bid.loanDetails.principal = _principal;
         bid.loanDetails.loanDuration = _duration;
         bid.loanDetails.timestamp = uint32(block.timestamp);

--- a/packages/contracts/contracts/TellerV2Autopay.sol
+++ b/packages/contracts/contracts/TellerV2Autopay.sol
@@ -115,7 +115,10 @@ contract TellerV2Autopay is OwnableUpgradeable, ITellerV2Autopay {
         address lendingToken = ITellerV2(tellerV2).getLoanLendingToken(_bidId);
         address borrower = ITellerV2(tellerV2).getLoanBorrower(_bidId);
 
-        uint256 amountToRepayMinimum = getEstimatedMinimumPayment(_bidId,block.timestamp);
+        uint256 amountToRepayMinimum = getEstimatedMinimumPayment(
+            _bidId,
+            block.timestamp
+        );
         uint256 autopayFeeAmount = amountToRepayMinimum.percent(
             getAutopayFee()
         );
@@ -144,7 +147,10 @@ contract TellerV2Autopay is OwnableUpgradeable, ITellerV2Autopay {
         virtual
         returns (uint256 _amount)
     {
-        Payment memory estimatedPayment = tellerV2.calculateAmountDue(_bidId,_timestamp);
+        Payment memory estimatedPayment = tellerV2.calculateAmountDue(
+            _bidId,
+            _timestamp
+        );
 
         _amount = estimatedPayment.principal + estimatedPayment.interest;
     }

--- a/packages/contracts/contracts/TellerV2Autopay.sol
+++ b/packages/contracts/contracts/TellerV2Autopay.sol
@@ -115,7 +115,7 @@ contract TellerV2Autopay is OwnableUpgradeable, ITellerV2Autopay {
         address lendingToken = ITellerV2(tellerV2).getLoanLendingToken(_bidId);
         address borrower = ITellerV2(tellerV2).getLoanBorrower(_bidId);
 
-        uint256 amountToRepayMinimum = getEstimatedMinimumPayment(_bidId);
+        uint256 amountToRepayMinimum = getEstimatedMinimumPayment(_bidId,block.timestamp);
         uint256 autopayFeeAmount = amountToRepayMinimum.percent(
             getAutopayFee()
         );
@@ -139,12 +139,12 @@ contract TellerV2Autopay is OwnableUpgradeable, ITellerV2Autopay {
         emit AutoPaidLoanMinimum(_bidId, msg.sender);
     }
 
-    function getEstimatedMinimumPayment(uint256 _bidId)
+    function getEstimatedMinimumPayment(uint256 _bidId, uint256 _timestamp)
         public
         virtual
         returns (uint256 _amount)
     {
-        Payment memory estimatedPayment = tellerV2.calculateAmountDue(_bidId);
+        Payment memory estimatedPayment = tellerV2.calculateAmountDue(_bidId,_timestamp);
 
         _amount = estimatedPayment.principal + estimatedPayment.interest;
     }

--- a/packages/contracts/contracts/TellerV2Storage.sol
+++ b/packages/contracts/contracts/TellerV2Storage.sol
@@ -5,7 +5,7 @@ import { IMarketRegistry } from "./interfaces/IMarketRegistry.sol";
 import "./interfaces/IEscrowVault.sol";
 import "./interfaces/IReputationManager.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/ICollateralManager.sol";
 import { PaymentType, PaymentCycleType } from "./libraries/V2Calculations.sol";
 import "./interfaces/ILenderManager.sol";
@@ -64,7 +64,7 @@ struct Bid {
  * @param loanDuration The duration of the loan.
  */
 struct LoanDetails {
-    ERC20 lendingToken;
+    IERC20 lendingToken;
     uint256 principal;
     Payment totalRepaid;
     uint32 timestamp;

--- a/packages/contracts/contracts/interfaces/ITellerV2.sol
+++ b/packages/contracts/contracts/interfaces/ITellerV2.sol
@@ -59,7 +59,7 @@ interface ITellerV2 {
             uint256 amountToBorrower
         );
 
-    function calculateAmountDue(uint256 _bidId)
+    function calculateAmountDue(uint256 _bidId, uint256 _timestamp)
         external
         view
         returns (Payment memory due);

--- a/packages/contracts/contracts/libraries/V2Calculations.sol
+++ b/packages/contracts/contracts/libraries/V2Calculations.sol
@@ -165,16 +165,12 @@ library V2Calculations {
             );
     }
 
-
-
     function calculateNextDueDate(
-         Bid storage bid,
-         uint32 lastRepaidTimestamp,
-         PaymentCycleType bidPaymentCycleType
-    ) public view returns (uint32 dueDate_){
-
-      //  uint32 lastRepaidTimestamp = lastRepaidTimestamp(_bidId);
-
+        Bid storage bid,
+        uint32 lastRepaidTimestamp,
+        PaymentCycleType bidPaymentCycleType
+    ) public view returns (uint32 dueDate_) {
+       
         // Calculate due date if payment cycle is set to monthly
         if (bidPaymentCycleType == PaymentCycleType.Monthly) {
             // Calculate the cycle number the last repayment was made
@@ -219,8 +215,5 @@ library V2Calculations {
         if (dueDate_ > endOfLoan) {
             dueDate_ = endOfLoan;
         }
-
-
     }
-
 }

--- a/packages/contracts/contracts/libraries/V2Calculations.sol
+++ b/packages/contracts/contracts/libraries/V2Calculations.sol
@@ -166,21 +166,21 @@ library V2Calculations {
     }
 
     function calculateNextDueDate(
-        Bid storage bid,
-        uint32 lastRepaidTimestamp,
-        PaymentCycleType bidPaymentCycleType
+        Bid storage _bid,
+        uint32 _lastRepaidTimestamp,
+        PaymentCycleType _bidPaymentCycleType
     ) public view returns (uint32 dueDate_) {
        
         // Calculate due date if payment cycle is set to monthly
-        if (bidPaymentCycleType == PaymentCycleType.Monthly) {
+        if (_bidPaymentCycleType == PaymentCycleType.Monthly) {
             // Calculate the cycle number the last repayment was made
             uint256 lastPaymentCycle = BPBDTL.diffMonths(
-                bid.loanDetails.acceptedTimestamp,
-                lastRepaidTimestamp
+                _bid.loanDetails.acceptedTimestamp,
+                _lastRepaidTimestamp
             );
             if (
-                BPBDTL.getDay(lastRepaidTimestamp) >
-                BPBDTL.getDay(bid.loanDetails.acceptedTimestamp)
+                BPBDTL.getDay(_lastRepaidTimestamp) >
+                BPBDTL.getDay(_bid.loanDetails.acceptedTimestamp)
             ) {
                 lastPaymentCycle += 2;
             } else {
@@ -189,28 +189,28 @@ library V2Calculations {
 
             dueDate_ = uint32(
                 BPBDTL.addMonths(
-                    bid.loanDetails.acceptedTimestamp,
+                    _bid.loanDetails.acceptedTimestamp,
                     lastPaymentCycle
                 )
             );
-        } else if (bidPaymentCycleType == PaymentCycleType.Seconds) {
+        } else if (_bidPaymentCycleType == PaymentCycleType.Seconds) {
             // Start with the original due date being 1 payment cycle since bid was accepted
             dueDate_ =
-                bid.loanDetails.acceptedTimestamp +
-                bid.terms.paymentCycle;
+                _bid.loanDetails.acceptedTimestamp +
+                _bid.terms.paymentCycle;
             // Calculate the cycle number the last repayment was made
-            uint32 delta = lastRepaidTimestamp -
-                bid.loanDetails.acceptedTimestamp;
+            uint32 delta = _lastRepaidTimestamp -
+                _bid.loanDetails.acceptedTimestamp;
             if (delta > 0) {
                 uint32 repaymentCycle = uint32(
-                    Math.ceilDiv(delta, bid.terms.paymentCycle)
+                    Math.ceilDiv(delta, _bid.terms.paymentCycle)
                 );
-                dueDate_ += (repaymentCycle * bid.terms.paymentCycle);
+                dueDate_ += (repaymentCycle * _bid.terms.paymentCycle);
             }
         }
 
-        uint32 endOfLoan = bid.loanDetails.acceptedTimestamp +
-            bid.loanDetails.loanDuration;
+        uint32 endOfLoan = _bid.loanDetails.acceptedTimestamp +
+            _bid.loanDetails.loanDuration;
         //if we are in the last payment cycle, the next due date is the end of loan duration
         if (dueDate_ > endOfLoan) {
             dueDate_ = endOfLoan;

--- a/packages/contracts/contracts/mock/TellerV2SolMock.sol
+++ b/packages/contracts/contracts/mock/TellerV2SolMock.sol
@@ -35,7 +35,7 @@ contract TellerV2SolMock is ITellerV2, TellerV2Storage {
         bid.borrower = msg.sender;
         bid.receiver = _receiver != address(0) ? _receiver : bid.borrower;
         bid.marketplaceId = _marketId;
-        bid.loanDetails.lendingToken = ERC20(_lendingToken);
+        bid.loanDetails.lendingToken = IERC20(_lendingToken);
         bid.loanDetails.principal = _principal;
         bid.loanDetails.loanDuration = _duration;
         bid.loanDetails.timestamp = uint32(block.timestamp);

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -200,7 +200,7 @@ export default <HardhatUserConfig>{
   },
 
   contractSizer: {
-    runOnCompile: skipContractSizer,
+    runOnCompile: !skipContractSizer,
     alphaSort: false,
     disambiguatePaths: false,
   },

--- a/packages/contracts/tests/NextDueDate_test.sol
+++ b/packages/contracts/tests/NextDueDate_test.sol
@@ -5,7 +5,6 @@ import "./Testable.sol";
 import "../contracts/TellerV2.sol";
 import { BokkyPooBahsDateTimeLibrary as BPBDTL } from "../contracts/libraries/DateTimeLib.sol";
 
-
 contract NextDueDate_Test is Testable, TellerV2 {
     Bid __bid;
 

--- a/packages/contracts/tests/NextDueDate_test.sol
+++ b/packages/contracts/tests/NextDueDate_test.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 
 import "./Testable.sol";
 import "../contracts/TellerV2.sol";
+import { BokkyPooBahsDateTimeLibrary as BPBDTL } from "../contracts/libraries/DateTimeLib.sol";
+
 
 contract NextDueDate_Test is Testable, TellerV2 {
     Bid __bid;

--- a/packages/contracts/tests/TellerV2/TellerV2_Test.sol
+++ b/packages/contracts/tests/TellerV2/TellerV2_Test.sol
@@ -184,9 +184,11 @@ contract TellerV2_Test is Testable {
 
         assertEq(collateralAmount, escrowBalance, "Collateral was not stored");
 
+        vm.warp(100000);
+
         // Repay loan
         uint256 borrowerBalanceBefore = wethMock.balanceOf(address(borrower));
-        Payment memory amountOwed = tellerV2.calculateAmountOwed(bidId);
+        Payment memory amountOwed = tellerV2.calculateAmountOwed(bidId,block.timestamp);
         borrower.addAllowance(
             address(daiMock),
             address(tellerV2),

--- a/packages/contracts/tests/TellerV2/TellerV2_Test.sol
+++ b/packages/contracts/tests/TellerV2/TellerV2_Test.sol
@@ -188,7 +188,10 @@ contract TellerV2_Test is Testable {
 
         // Repay loan
         uint256 borrowerBalanceBefore = wethMock.balanceOf(address(borrower));
-        Payment memory amountOwed = tellerV2.calculateAmountOwed(bidId,block.timestamp);
+        Payment memory amountOwed = tellerV2.calculateAmountOwed(
+            bidId,
+            block.timestamp
+        );
         borrower.addAllowance(
             address(daiMock),
             address(tellerV2),

--- a/packages/contracts/tests/TellerV2/TellerV2_getData.sol
+++ b/packages/contracts/tests/TellerV2/TellerV2_getData.sol
@@ -376,7 +376,7 @@ contract TellerV2_initialize is Testable {
 
         tellerV2.mock_setBidState(bidId, BidState.ACCEPTED);
 
-        Payment memory amountDue = tellerV2.calculateAmountDue(bidId);
+        Payment memory amountDue = tellerV2.calculateAmountDue(bidId,block.timestamp);
 
         assertEq(amountDue.principal, 2);
     }
@@ -413,7 +413,7 @@ contract TellerV2_initialize is Testable {
 
         tellerV2.mock_setBidState(bidId, BidState.PENDING);
 
-        Payment memory amountDue = tellerV2.calculateAmountDue(bidId);
+        Payment memory amountDue = tellerV2.calculateAmountDue(bidId,block.timestamp);
 
         assertEq(amountDue.principal, 0);
     }
@@ -524,7 +524,7 @@ contract TellerV2_initialize is Testable {
         tellerV2.mock_setBidState(bidId, BidState.ACCEPTED);
         vm.warp(2500);
 
-        Payment memory amountOwed = tellerV2.calculateAmountOwed(bidId);
+        Payment memory amountOwed = tellerV2.calculateAmountOwed(bidId,block.timestamp);
 
         assertEq(amountOwed.principal, 100);
     }

--- a/packages/contracts/tests/TellerV2/TellerV2_getData.sol
+++ b/packages/contracts/tests/TellerV2/TellerV2_getData.sol
@@ -376,7 +376,10 @@ contract TellerV2_initialize is Testable {
 
         tellerV2.mock_setBidState(bidId, BidState.ACCEPTED);
 
-        Payment memory amountDue = tellerV2.calculateAmountDue(bidId,block.timestamp);
+        Payment memory amountDue = tellerV2.calculateAmountDue(
+            bidId,
+            block.timestamp
+        );
 
         assertEq(amountDue.principal, 2);
     }
@@ -413,7 +416,10 @@ contract TellerV2_initialize is Testable {
 
         tellerV2.mock_setBidState(bidId, BidState.PENDING);
 
-        Payment memory amountDue = tellerV2.calculateAmountDue(bidId,block.timestamp);
+        Payment memory amountDue = tellerV2.calculateAmountDue(
+            bidId,
+            block.timestamp
+        );
 
         assertEq(amountDue.principal, 0);
     }
@@ -524,7 +530,10 @@ contract TellerV2_initialize is Testable {
         tellerV2.mock_setBidState(bidId, BidState.ACCEPTED);
         vm.warp(2500);
 
-        Payment memory amountOwed = tellerV2.calculateAmountOwed(bidId,block.timestamp);
+        Payment memory amountOwed = tellerV2.calculateAmountOwed(
+            bidId,
+            block.timestamp
+        );
 
         assertEq(amountOwed.principal, 100);
     }

--- a/packages/contracts/tests/TellerV2Autopay_Test.sol
+++ b/packages/contracts/tests/TellerV2Autopay_Test.sol
@@ -200,7 +200,7 @@ contract TellerV2Autopay_Test is Testable, TellerV2Autopay {
         assertEq(borrowerBalanceDelta, 4002, "borrower did not autopay");
     }
 
-    function getEstimatedMinimumPayment(uint256 _bidId,uint256 _timestamp)
+    function getEstimatedMinimumPayment(uint256 _bidId, uint256 _timestamp)
         public
         override
         returns (uint256 _amount)

--- a/packages/contracts/tests/TellerV2Autopay_Test.sol
+++ b/packages/contracts/tests/TellerV2Autopay_Test.sol
@@ -200,7 +200,7 @@ contract TellerV2Autopay_Test is Testable, TellerV2Autopay {
         assertEq(borrowerBalanceDelta, 4002, "borrower did not autopay");
     }
 
-    function getEstimatedMinimumPayment(uint256 _bidId)
+    function getEstimatedMinimumPayment(uint256 _bidId,uint256 _timestamp)
         public
         override
         returns (uint256 _amount)


### PR DESCRIPTION
-changed ERC20 to IERC20

-moved CalculateNextDueDate logic into the V2Calc lib (this helped a MASSIVE amount, reducing size by a whopping 2.2 kb)

-removed the functions 'calculateAmountDue' and 'calculateAmountOwed' but only the versions that do not take a specific timestamp as they are redundant. expectation is that users can just pass in the current timestamp to the variant that asks for one instead. This removed about 0.5 kb from the contract as it deletes 2 whole functions.  This forced me to make a slight change to Autopay contract. Really a non-change as functionality of it does not change at all. 