### PR TITLE
adding reentrancy guard

### DIFF
--- a/packages/contracts/contracts/LenderCommitmentForwarder/SmartCommitmentForwarder.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder/SmartCommitmentForwarder.sol
@@ -19,6 +19,8 @@ import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
 
 
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+
 import { CommitmentCollateralType, ISmartCommitment } from "../interfaces/ISmartCommitment.sol";
 
  
@@ -26,6 +28,7 @@ contract SmartCommitmentForwarder is
     ExtensionsContextUpgradeable, //this should always be first for upgradeability
     TellerV2MarketForwarder_G3,
     PausableUpgradeable,  //this does add some storage but AFTER all other storage
+     ReentrancyGuardUpgradeable,  //adds many storage slots so breaks upgradeability 
     ISmartCommitmentForwarder,
     IPausableTimestamp
      {
@@ -102,7 +105,7 @@ contract SmartCommitmentForwarder is
         address _recipient,
         uint16 _interestRate,
         uint32 _loanDuration
-    ) public whenNotPaused returns (uint256 bidId) {
+    ) public whenNotPaused nonReentrant returns (uint256 bidId) {
         require(
             ISmartCommitment(_smartCommitmentAddress)
                 .getCollateralTokenType() <=

--- a/packages/contracts/deploy/lender_commitment_forwarder/extensions/lender_commitment_group_beacon.ts
+++ b/packages/contracts/deploy/lender_commitment_forwarder/extensions/lender_commitment_group_beacon.ts
@@ -24,6 +24,11 @@ const deployFn: DeployFunction = async (hre) => {
 
   const tellerV2Address = await tellerV2.getAddress()
 
+
+  const uniswapPricingLibrary = await hre.contracts.get('UniswapPricingLibrary')
+
+ 
+
   const smartCommitmentForwarderAddress =
     await SmartCommitmentForwarder.getAddress()
 
@@ -60,6 +65,9 @@ const deployFn: DeployFunction = async (hre) => {
         smartCommitmentForwarderAddress,
         uniswapV3FactoryAddress,
       ],
+      libraries: {
+        UniswapPricingLibrary: await uniswapPricingLibrary.getAddress(),
+      },
       
     }
   )

--- a/packages/contracts/deploy/lender_commitment_forwarder/extensions/lender_commitment_group_test.ts
+++ b/packages/contracts/deploy/lender_commitment_forwarder/extensions/lender_commitment_group_test.ts
@@ -93,7 +93,9 @@ deployFn.dependencies = [
   'smart-commitment-forwarder:deploy',
 ]
 
+
+//this is deprecated ....  use factory
 deployFn.skip = async (hre) => {
-  return !hre.network.live || !['sepolia', 'polygon'].includes(hre.network.name)
+  return !hre.network.live || !['sepolia'].includes(hre.network.name)
 }
 export default deployFn

--- a/packages/contracts/deployments/polygon/.migrations.json
+++ b/packages/contracts/deployments/polygon/.migrations.json
@@ -28,17 +28,13 @@
   "lender-commitment-forwarder:extensions:loan-referral-forwarder:deploy": 1724268455,
   "lender-commitment-forwarder:extensions:flash-rollover-widget:deploy": 1724268867,
   "lender-commitment-forwarder:alpha:upgrade_referrals": 1724423940,
-  "smart-commitment-forwarder:deploy": 1725390305,
-  "lender-commitment-group-smart:deploy": 1725891057,
-  "lender-commitment-group-beacon:deploy": 1726068317,
-  "lender-commitment-group-factory:deploy": 1726068336,
   "teller-v2:pausing-upgrade": 1727280937,
   "lender-commitment-group-factory:upgrade-multihop": 1727465789,
   "smart-commitment-forwarder:upgrade-pausing": 1727811173,
-   
   "loan-referral-forwarder:upgrade_1": 1729024662,
   "protocol-pausing-manager:deploy": 1728941512,
   "teller-v2:pausing-manager-upgrade": 1729002281,
   "teller-v2:pausing-manager-upgrade-v2": 1729011159,
-  "lender-commitment-group-beacon:upgrade": 1729179210
+  "lender-commitment-group-beacon:upgrade": 1729179210,
+  "smart-commitment-forwarder:deploy": 1730300987
 }

--- a/packages/contracts/deployments/polygon/LenderCommitmentGroupBeacon.json
+++ b/packages/contracts/deployments/polygon/LenderCommitmentGroupBeacon.json
@@ -1399,6 +1399,6 @@
     }
   ],
   "receipt": {},
-  "numDeployments": 9,
-  "implementation": "0x55Ef5d3700eEC151d4Feff74214E7C90daBDE12B"
+  "numDeployments": 10,
+  "implementation": "0x98c1A3E3C0eDfef8db0f1525B07F92d4DFD4ac71"
 }

--- a/packages/contracts/deployments/polygon/SmartCommitmentForwarder.json
+++ b/packages/contracts/deployments/polygon/SmartCommitmentForwarder.json
@@ -397,6 +397,6 @@
     "blockHash": null,
     "blockNumber": null
   },
-  "numDeployments": 4,
-  "implementation": "0xb9636C8b00a838B8b30502A2dD3bF18aa473AE0c"
+  "numDeployments": 5,
+  "implementation": "0xF579ba9Ce33E392134Fd4a1A9D7D9d792eAF0B2b"
 }


### PR DESCRIPTION
Adds reentrancy guards to lender groups , borrow actions and lender actions 

Breaks compatibility with storage slots for SCF and LenderGroups ( redeploy factory) 


** Once any function with re-entrancy guard is called in a tx, NO OTHER functions with re-entracy guard can be called in that tx.  **   (this is just how it works)  