### PR TITLE
Upgrade FlashSwapRollover for Sushiswap + Anvil test 

### DIFF
--- a/packages/contracts/.openzeppelin/unknown-747474.json
+++ b/packages/contracts/.openzeppelin/unknown-747474.json
@@ -3872,6 +3872,16 @@
         },
         "namespaces": {}
       }
+    },
+    "3bb32c2d4934d94d3a3927904b4e7aadcdc9ff84d40175d7dd9d6ea0dc4d5f19": {
+      "address": "0x838F8e08C723CA4323cacD07D57777B27eAB3bD4",
+      "txHash": "0x5aeca30c304eb9f5c9475b7218bdc9259926c232dcc5b20dc84edce265b9c3cd",
+      "layout": {
+        "solcVersion": "0.8.11",
+        "storage": [],
+        "types": {},
+        "namespaces": {}
+      }
     }
   }
 }

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -38,3 +38,19 @@ Some deployment files are stored using LFS.  To fetch these, use the command
  git lfs fetch --all
 
 ```
+
+
+
+### Running tests 
+
+``` yarn contracts test ```
+
+
+``` 
+
+anvil --fork-url https://rpc.katana.network 
+
+
+yarn contracts test_forked 
+
+``` 

--- a/packages/contracts/contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
  
-import "./SwapRolloverLoan_G1.sol";
+import "./SwapRolloverLoan_G2.sol";
 
-contract SwapRolloverLoan is SwapRolloverLoan_G1 {
+contract SwapRolloverLoan is SwapRolloverLoan_G2 {
     constructor(
         address _tellerV2, 
         address _factory,
         address _WETH9
     )
-        SwapRolloverLoan_G1(
+        SwapRolloverLoan_G2(
             _tellerV2,
             _factory,
             _WETH9

--- a/packages/contracts/contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan_G2.sol
+++ b/packages/contracts/contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan_G2.sol
@@ -7,32 +7,33 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // Interfaces
-import "../interfaces/ITellerV2.sol";
-import "../interfaces/IProtocolFee.sol";
-import "../interfaces/ITellerV2Storage.sol";
-import "../interfaces/IMarketRegistry.sol";
-import "../interfaces/ILenderCommitmentForwarder.sol";
-import "../interfaces/ISmartCommitmentForwarder.sol";
-import "../interfaces/ISwapRolloverLoan.sol";
-import "../libraries/NumbersLib.sol";
+import "../../../interfaces/ITellerV2.sol";
+import "../../../interfaces/IProtocolFee.sol";
+import "../../../interfaces/ITellerV2Storage.sol";
+import "../../../interfaces/IMarketRegistry.sol";
+import "../../../interfaces/ILenderCommitmentForwarder.sol";
+import "../../../interfaces/ISmartCommitmentForwarder.sol";
+import "../../../interfaces/ISwapRolloverLoan.sol";
+import "../../../libraries/NumbersLib.sol";
 
  
-import '../libraries/uniswap/periphery/base/PeripheryPayments.sol';
-import '../libraries/uniswap/periphery/base/PeripheryImmutableState.sol';
-import '../libraries/uniswap/periphery/libraries/PoolAddress.sol';
-import '../libraries/uniswap/periphery/libraries/CallbackValidation.sol';
-import '../libraries/uniswap/periphery/libraries/TransferHelper.sol';
-import '../libraries/uniswap/periphery/interfaces/ISwapRouter.sol';
+import '../../../libraries/uniswap/periphery/base/PeripheryPayments.sol';
+import '../../../libraries/uniswap/periphery/base/PeripheryImmutableState.sol';
+import '../../../libraries/uniswap/periphery/libraries/PoolAddress.sol';
+import '../../../libraries/uniswap/periphery/libraries/CallbackValidation.sol';
+import '../../../libraries/uniswap/periphery/libraries/TransferHelper.sol';
+import '../../../libraries/uniswap/periphery/interfaces/ISwapRouter.sol';
 
-import '../libraries/uniswap/core/interfaces/IUniswapV3Factory.sol';
+import '../../../libraries/uniswap/core/interfaces/IUniswapV3Factory.sol';
 
-import '../libraries/uniswap/core/libraries/LowGasSafeMath.sol';
+import '../../../libraries/uniswap/core/libraries/LowGasSafeMath.sol';
 
-import '../libraries/uniswap/core/interfaces/callback/IUniswapV3FlashCallback.sol';
+import '../../../libraries/uniswap/core/interfaces/callback/IUniswapV3FlashCallback.sol';
  
-  
+ 
 
-contract MockSwapRolloverLoan is IUniswapV3FlashCallback, PeripheryPayments  {
+
+contract SwapRolloverLoan_G2 is IUniswapV3FlashCallback, PeripheryPayments  {
     using AddressUpgradeable for address;
     using NumbersLib for uint256;
 
@@ -278,12 +279,10 @@ contract MockSwapRolloverLoan is IUniswapV3FlashCallback, PeripheryPayments  {
         uint256 fee1,
         bytes calldata data
     ) external override {
-
-       
         RolloverCallbackArgs memory _rolloverArgs = abi.decode(data, (RolloverCallbackArgs));
       
 
-        
+
 
         AcceptCommitmentArgs memory acceptCommitmentArgs = abi.decode(
             _rolloverArgs.acceptCommitmentArgs,
@@ -297,6 +296,7 @@ contract MockSwapRolloverLoan is IUniswapV3FlashCallback, PeripheryPayments  {
 
         );
 
+    
        
         _verifyFlashCallback(  
             flashSwapArgs.token0,
@@ -304,8 +304,6 @@ contract MockSwapRolloverLoan is IUniswapV3FlashCallback, PeripheryPayments  {
             flashSwapArgs.fee,
             msg.sender 
          );
-       
-             
 
         address flashToken = flashSwapArgs.borrowToken1 ? flashSwapArgs.token1: flashSwapArgs.token0  ; 
         uint256 flashFee =  flashSwapArgs.borrowToken1 ? fee1: fee0 ;
@@ -377,6 +375,8 @@ contract MockSwapRolloverLoan is IUniswapV3FlashCallback, PeripheryPayments  {
     }
 
 
+    
+  
     /*
         Verify the flash callback with a remote call to the factory 
         @dev This allows better compatibility with factories that have different 'init hashes' such as forks like sushi 

--- a/packages/contracts/contracts/mock/SwapRolloverLoanMock.sol
+++ b/packages/contracts/contracts/mock/SwapRolloverLoanMock.sol
@@ -1,0 +1,649 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Contracts
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+// Interfaces
+import "../interfaces/ITellerV2.sol";
+import "../interfaces/IProtocolFee.sol";
+import "../interfaces/ITellerV2Storage.sol";
+import "../interfaces/IMarketRegistry.sol";
+import "../interfaces/ILenderCommitmentForwarder.sol";
+import "../interfaces/ISmartCommitmentForwarder.sol";
+import "../interfaces/ISwapRolloverLoan.sol";
+import "../libraries/NumbersLib.sol";
+
+ 
+import '../libraries/uniswap/periphery/base/PeripheryPayments.sol';
+import '../libraries/uniswap/periphery/base/PeripheryImmutableState.sol';
+import '../libraries/uniswap/periphery/libraries/PoolAddress.sol';
+import '../libraries/uniswap/periphery/libraries/CallbackValidation.sol';
+import '../libraries/uniswap/periphery/libraries/TransferHelper.sol';
+import '../libraries/uniswap/periphery/interfaces/ISwapRouter.sol';
+
+import '../libraries/uniswap/core/interfaces/IUniswapV3Factory.sol';
+
+import '../libraries/uniswap/core/libraries/LowGasSafeMath.sol';
+
+import '../libraries/uniswap/core/interfaces/callback/IUniswapV3FlashCallback.sol';
+ 
+ 
+import "forge-std/console.sol";
+
+
+contract MockSwapRolloverLoan is IUniswapV3FlashCallback, PeripheryPayments  {
+    using AddressUpgradeable for address;
+    using NumbersLib for uint256;
+
+
+    using LowGasSafeMath for uint256;
+    using LowGasSafeMath for int256;
+
+   
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    ITellerV2 public immutable TELLER_V2;
+  
+     
+
+    event RolloverLoanComplete(
+        address borrower,
+        uint256 originalLoanId,
+        uint256 newLoanId,
+        uint256 fundsRemaining
+    );
+
+     event RolloverWithReferral(
+        
+        uint256 newLoanId,
+        address flashToken,
+
+        address rewardRecipient,
+        uint256 rewardAmount,
+        uint256 atmId
+    );
+
+ 
+
+    struct AcceptCommitmentArgs {
+        uint256 commitmentId;
+        address smartCommitmentAddress;  //if this is not address(0), we will use this ! leave empty if not used. 
+        uint256 principalAmount;
+        uint256 collateralAmount;
+        uint256 collateralTokenId;
+        address collateralTokenAddress;
+        uint16 interestRate;
+        uint32 loanDuration;
+        bytes32[] merkleProof; //empty array if not used
+    }
+
+    struct FlashSwapArgs {
+
+        address token0;
+        address token1;
+        uint24 fee;
+ 
+
+        uint256 flashAmount;
+        bool borrowToken1; // if false, borrow token 0 
+       
+        
+
+    } 
+
+       struct RolloverCallbackArgs {
+        address lenderCommitmentForwarder;
+        uint256 loanId;
+        address borrower;
+        uint256 borrowerAmount;
+        uint256 atmId; 
+        address rewardRecipient;
+        uint256 rewardAmount;
+        bytes acceptCommitmentArgs;
+        bytes flashSwapArgs;
+    }
+
+
+    /**
+     *
+     * @notice Initializes the FlashRolloverLoan with necessary contract addresses.
+     *
+     * @dev Using a custom OpenZeppelin upgrades tag. Ensure the constructor logic is safe for upgrades.
+     *
+     * @param _tellerV2 The address of the TellerV2 contract.
+     * @param _factory The address of the UniswapV3 Factory contract to help with callback validation.
+     * @param _WETH9 The address of the WETH Contract as this is instrumental to core uniswap logic.
+     */
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(
+        address _tellerV2, 
+        address _factory,
+        address _WETH9
+    ) PeripheryImmutableState(_factory, _WETH9)  {
+        TELLER_V2 = ITellerV2(_tellerV2);
+     
+    }
+ 
+
+
+
+    /**
+     *
+     * @notice Allows the borrower to rollover their existing loan using a flash loan mechanism.
+     *         The borrower might also provide an additional amount during the rollover.
+     *
+     * @dev The function first verifies that the caller is the borrower of the loan.
+     *      It then optionally transfers the additional amount specified by the borrower.
+     *      A flash loan is then taken from the pool to facilitate the rollover and
+     *      a callback is executed for further operations.
+     *
+     * @param _loanId Identifier of the existing loan to be rolled over.
+     
+     * @param _borrowerAmount Additional amount that the borrower may want to add during rollover.
+     * @param _acceptCommitmentArgs Commitment arguments that might be necessary for internal operations.
+     * 
+     */
+    function rolloverLoanWithFlashSwap(
+        address _lenderCommitmentForwarder,
+        uint256 _loanId, 
+
+        uint256 _borrowerAmount, //an additional amount borrower may have to add 
+
+        FlashSwapArgs calldata _flashSwapArgs, 
+
+        AcceptCommitmentArgs calldata _acceptCommitmentArgs
+
+    ) external   {
+        address borrower = TELLER_V2.getLoanBorrower(_loanId);
+        require(borrower == msg.sender, "Must be borrower");
+
+
+        {
+            // Get lending token and balance before
+            address lendingToken = TELLER_V2.getLoanLendingToken(_loanId);
+
+          
+            if (_borrowerAmount > 0) {
+                TransferHelper.safeTransferFrom(lendingToken, borrower, address(this), _borrowerAmount);              
+            }
+        }
+
+        
+        IUniswapV3Pool( 
+            getUniswapPoolAddress (
+                _flashSwapArgs.token0,
+                _flashSwapArgs.token1,
+                _flashSwapArgs.fee
+            )
+        ).flash(  
+            address(this),
+           _flashSwapArgs.borrowToken1 ? 0 : _flashSwapArgs.flashAmount,            
+           _flashSwapArgs.borrowToken1 ?  _flashSwapArgs.flashAmount : 0, 
+            abi.encode( 
+                RolloverCallbackArgs({
+                    lenderCommitmentForwarder : _lenderCommitmentForwarder,
+                    loanId: _loanId,
+                    borrower: borrower,
+                    borrowerAmount: _borrowerAmount, 
+                    rewardRecipient: address(0),
+                    rewardAmount: 0,
+                    atmId: 0, 
+                    acceptCommitmentArgs: abi.encode(_acceptCommitmentArgs),
+
+                    flashSwapArgs: abi.encode( _flashSwapArgs) 
+                    
+                })
+
+            )
+        );
+
+
+        
+    }
+
+
+
+    function rolloverLoanWithFlashSwapRewards(
+        address _lenderCommitmentForwarder,
+        uint256 _loanId, 
+
+        uint256 _borrowerAmount, //an additional amount borrower may have to add
+        uint256 _rewardAmount,
+        address _rewardRecipient,
+        uint256 _atmId, //optional, just for analytics 
+
+        FlashSwapArgs calldata _flashSwapArgs, 
+
+        AcceptCommitmentArgs calldata _acceptCommitmentArgs
+
+    ) external   {
+        address borrower = TELLER_V2.getLoanBorrower(_loanId);
+        require(borrower == msg.sender, "Must be borrower");
+
+
+        {
+            // Get lending token and balance before
+            address lendingToken = TELLER_V2.getLoanLendingToken(_loanId);
+
+             require( 
+                  _rewardAmount <= _flashSwapArgs.flashAmount / 10 ,
+                   "Excessive reward amount" );
+
+            if (_borrowerAmount > 0) {
+                TransferHelper.safeTransferFrom(lendingToken, borrower, address(this), _borrowerAmount);              
+            }
+        } 
+       
+
+        IUniswapV3Pool( 
+            getUniswapPoolAddress (
+                _flashSwapArgs.token0,
+                _flashSwapArgs.token1,
+                _flashSwapArgs.fee
+            )
+        ).flash(
+            address(this),
+           _flashSwapArgs.borrowToken1 ? 0 : _flashSwapArgs.flashAmount,            
+           _flashSwapArgs.borrowToken1 ?  _flashSwapArgs.flashAmount : 0, 
+            abi.encode( 
+                RolloverCallbackArgs({
+                    lenderCommitmentForwarder : _lenderCommitmentForwarder,
+                    loanId: _loanId,
+                    borrower: borrower,
+                    borrowerAmount: _borrowerAmount, // need this ? 
+                    rewardRecipient: _rewardRecipient,
+                    rewardAmount: _rewardAmount,
+                    atmId: _atmId, 
+                    acceptCommitmentArgs: abi.encode(_acceptCommitmentArgs), 
+                    flashSwapArgs: abi.encode( _flashSwapArgs) 
+                    
+                })
+
+            )
+        );
+
+
+        
+    }
+
+
+
+
+    /*
+        @dev  _verifyFlashCallback ensures that only the uniswap pool can call this method 
+    */
+    function uniswapV3FlashCallback(
+        uint256 fee0,
+        uint256 fee1,
+        bytes calldata data
+    ) external override {
+
+        console.log("flash callback 1 ");
+        RolloverCallbackArgs memory _rolloverArgs = abi.decode(data, (RolloverCallbackArgs));
+      
+
+         console.log("flash callback 2");
+
+        AcceptCommitmentArgs memory acceptCommitmentArgs = abi.decode(
+            _rolloverArgs.acceptCommitmentArgs,
+            (AcceptCommitmentArgs)
+        );
+
+        FlashSwapArgs memory flashSwapArgs = abi.decode(
+
+            _rolloverArgs.flashSwapArgs,
+            (FlashSwapArgs)
+
+        );
+
+            console.log("flash callback 3");
+        PoolAddress.PoolKey memory poolKey =
+            PoolAddress.PoolKey({token0: flashSwapArgs.token0, token1: flashSwapArgs.token1, fee: flashSwapArgs.fee}); 
+
+        _verifyFlashCallback( factory , poolKey  );
+       
+                console.log("flash callback 4");
+
+        address flashToken = flashSwapArgs.borrowToken1 ? flashSwapArgs.token1: flashSwapArgs.token0  ; 
+        uint256 flashFee =  flashSwapArgs.borrowToken1 ? fee1: fee0 ;
+
+
+
+        uint256 repaymentAmount = _repayLoanFull(
+            _rolloverArgs.loanId, 
+            flashToken,
+            flashSwapArgs.flashAmount
+        );
+
+    
+
+        // Accept commitment and receive funds to this contract 
+        (uint256 newLoanId, uint256 acceptCommitmentAmount) = _acceptCommitment(
+            _rolloverArgs.lenderCommitmentForwarder,
+            _rolloverArgs.borrower,
+            flashToken,
+            acceptCommitmentArgs
+        );
+
+       
+        uint256 amountOwedToPool = LowGasSafeMath.add(flashSwapArgs.flashAmount, flashFee) ; 
+ 
+        // what is the point of this ?? 
+        // TransferHelper.safeApprove(flashToken, address(this), amountOwedToPool);
+      
+        //  msg.sender is the uniswap pool  
+        if (amountOwedToPool > 0) pay(flashToken, address(this), msg.sender, amountOwedToPool);
+     
+ 
+        // send any dust to the borrower
+         uint256 fundsRemaining = flashSwapArgs.flashAmount + 
+              acceptCommitmentAmount +
+            _rolloverArgs.borrowerAmount -
+            repaymentAmount -
+            amountOwedToPool;
+ 
+    
+          if (fundsRemaining > 0) {
+
+            if (_rolloverArgs.rewardAmount > 0){ 
+
+                fundsRemaining -= _rolloverArgs.rewardAmount;
+                TransferHelper.safeTransfer(flashToken,   _rolloverArgs.rewardRecipient,   _rolloverArgs.rewardAmount) ;
+
+                emit RolloverWithReferral( newLoanId, flashToken, _rolloverArgs.rewardRecipient,   _rolloverArgs.rewardAmount, _rolloverArgs.atmId     ) ;  
+                  
+            }
+
+           TransferHelper.safeTransfer(flashToken,  _rolloverArgs.borrower,   fundsRemaining) ;
+                 
+            
+        }
+
+
+
+        emit RolloverLoanComplete(
+            _rolloverArgs.borrower,
+            _rolloverArgs.loanId,
+            newLoanId,
+            fundsRemaining
+        );
+
+    
+
+
+    }
+
+
+    
+    function _verifyFlashCallback( 
+        address _factory,
+        PoolAddress.PoolKey memory _poolKey 
+     ) internal virtual {
+
+        CallbackValidation.verifyCallback(_factory,  _poolKey); //verifies that only uniswap contract can call this fn 
+
+    }
+
+
+    function getUniswapPoolAddress(  
+        address token0,
+        address token1,
+        uint24 fee
+     ) public view virtual returns (address) {
+
+        return IUniswapV3Factory(factory).getPool(token0,token1,fee);
+
+    }
+
+
+    /**
+     *
+     *
+     * @notice Internal function that repays a loan in full on behalf of this contract.
+     *
+     * @dev The function first calculates the funds held by the contract before repayment, then approves
+     *      the repayment amount to the TellerV2 contract and finally repays the loan in full.
+     *
+     * @param _bidId Identifier of the loan to be repaid.
+     * @param _principalToken The token in which the loan was originated.
+     * @param _repayAmount The amount to be repaid.
+     *
+     * @return repayAmount_ The actual amount that was used for repayment.
+     */
+    function _repayLoanFull(
+        uint256 _bidId,
+        address _principalToken,
+        uint256 _repayAmount
+    ) internal returns (uint256 repayAmount_) {
+        uint256 fundsBeforeRepayment = IERC20Upgradeable(_principalToken)
+            .balanceOf(address(this));
+
+        IERC20Upgradeable(_principalToken).approve(
+            address(TELLER_V2),
+            _repayAmount
+        );
+        TELLER_V2.repayLoanFull(_bidId);
+
+        uint256 fundsAfterRepayment = IERC20Upgradeable(_principalToken)
+            .balanceOf(address(this));
+
+        repayAmount_ = fundsBeforeRepayment - fundsAfterRepayment;
+    }
+
+    /**
+     *
+     *
+     * @notice Accepts a loan commitment using either a Merkle proof or standard method.
+     *
+     * @dev The function first checks if a Merkle proof is provided, based on which it calls the relevant
+     *      `acceptCommitment` function in the LenderCommitmentForwarder contract.
+     *
+     * @param borrower The address of the borrower for whom the commitment is being accepted.
+     * @param principalToken The token in which the loan is being accepted.
+     * @param _commitmentArgs The arguments necessary for accepting the commitment.
+     *
+     * @return bidId_ Identifier of the accepted loan.
+     * @return acceptCommitmentAmount_ The amount received from accepting the commitment.
+     */
+    function _acceptCommitment(
+        address lenderCommitmentForwarder,
+        address borrower,
+        address principalToken,
+        AcceptCommitmentArgs memory _commitmentArgs
+    )
+        internal
+        virtual
+        returns (uint256 bidId_, uint256 acceptCommitmentAmount_)
+    {
+        uint256 fundsBeforeAcceptCommitment = IERC20Upgradeable(principalToken)
+            .balanceOf(address(this));
+
+
+
+        if (_commitmentArgs.smartCommitmentAddress != address(0)) {
+
+             bytes memory responseData = address(lenderCommitmentForwarder)
+                    .functionCall(
+                        abi.encodePacked(
+                            abi.encodeWithSelector(
+                                ISmartCommitmentForwarder
+                                    .acceptSmartCommitmentWithRecipient
+                                    .selector,
+                                _commitmentArgs.smartCommitmentAddress,
+                                _commitmentArgs.principalAmount,
+                                _commitmentArgs.collateralAmount,
+                                _commitmentArgs.collateralTokenId,
+                                _commitmentArgs.collateralTokenAddress,
+                                address(this),
+                                _commitmentArgs.interestRate,
+                                _commitmentArgs.loanDuration
+                            ),
+                            borrower //cant be msg.sender because of the flash flow
+                        )
+                    );
+
+                (bidId_) = abi.decode(responseData, (uint256));
+
+
+        }else { 
+
+            bool usingMerkleProof = _commitmentArgs.merkleProof.length > 0;
+
+            if (usingMerkleProof) {
+                bytes memory responseData = address(lenderCommitmentForwarder)
+                    .functionCall(
+                        abi.encodePacked(
+                            abi.encodeWithSelector(
+                                ILenderCommitmentForwarder
+                                    .acceptCommitmentWithRecipientAndProof
+                                    .selector,
+                                _commitmentArgs.commitmentId,
+                                _commitmentArgs.principalAmount,
+                                _commitmentArgs.collateralAmount,
+                                _commitmentArgs.collateralTokenId,
+                                _commitmentArgs.collateralTokenAddress,
+                                address(this),
+                                _commitmentArgs.interestRate,
+                                _commitmentArgs.loanDuration,
+                                _commitmentArgs.merkleProof
+                            ),
+                            borrower //cant be msg.sender because of the flash flow
+                        )
+                    );
+
+                (bidId_) = abi.decode(responseData, (uint256));
+            } else {
+                bytes memory responseData = address(lenderCommitmentForwarder)
+                    .functionCall(
+                        abi.encodePacked(
+                            abi.encodeWithSelector(
+                                ILenderCommitmentForwarder
+                                    .acceptCommitmentWithRecipient
+                                    .selector,
+                                _commitmentArgs.commitmentId,
+                                _commitmentArgs.principalAmount,
+                                _commitmentArgs.collateralAmount,
+                                _commitmentArgs.collateralTokenId,
+                                _commitmentArgs.collateralTokenAddress,
+                                address(this),
+                                _commitmentArgs.interestRate,
+                                _commitmentArgs.loanDuration
+                            ),
+                            borrower //cant be msg.sender because of the flash flow
+                        )
+                    );
+
+                (bidId_) = abi.decode(responseData, (uint256));
+            }
+
+        }
+
+        uint256 fundsAfterAcceptCommitment = IERC20Upgradeable(principalToken)
+            .balanceOf(address(this));
+        acceptCommitmentAmount_ =
+            fundsAfterAcceptCommitment -
+            fundsBeforeAcceptCommitment;
+    }
+
+   
+
+    /**
+     * @notice Calculates the amount for loan rollover, determining if the borrower owes or receives funds.
+    
+     */
+    function calculateRolloverAmount(
+        uint16 marketFeePct,
+        uint16 protocolFeePct, 
+        uint256 _loanId,      
+        uint256 principalAmount,
+        uint256 _rewardAmount, 
+        uint16 _flashloanFeePct,  // 3000 means 0.3%  in uniswap terms
+        uint256 _timestamp
+    ) external view returns (uint256 _flashAmount, int256 _borrowerAmount) {
+        
+
+        Payment memory repayAmountOwed = TELLER_V2.calculateAmountOwed(
+            _loanId,
+            _timestamp
+        );
+
+        uint256 commitmentPrincipalRequested = principalAmount; // _commitmentArgs.principalAmount;
+        uint256 amountToMarketplace = commitmentPrincipalRequested.percent(
+            marketFeePct
+        );
+        uint256 amountToProtocol = commitmentPrincipalRequested.percent(
+            protocolFeePct
+        );
+
+        uint256 commitmentPrincipalReceived = commitmentPrincipalRequested -
+            amountToMarketplace -
+            amountToProtocol;
+
+        // by default, we will flash exactly what we need to do relayLoanFull
+        uint256 repayFullAmount = repayAmountOwed.principal +
+            repayAmountOwed.interest;
+
+        _flashAmount = repayFullAmount;
+        uint256 _flashLoanFee = _flashAmount.percent(_flashloanFeePct, 4 );
+
+        _borrowerAmount =
+            int256(commitmentPrincipalReceived) -
+            int256(repayFullAmount) -
+            int256(_flashLoanFee) -
+            int256(_rewardAmount);
+
+            
+    }
+
+
+     function getMarketIdForCommitment(
+       address _lenderCommitmentForwarder, 
+       uint256 _commitmentId
+    ) external view returns (uint256) {
+        return _getMarketIdForCommitment(_lenderCommitmentForwarder, _commitmentId);  
+    }
+
+    function getMarketFeePct(
+       uint256 _marketId
+    ) external view returns (uint16) {
+        return _getMarketFeePct(_marketId);  
+    }
+   
+
+    /**
+     * @notice Retrieves the market ID associated with a given commitment.
+     * @param _commitmentId The ID of the commitment for which to fetch the market ID.
+     * @return The ID of the market associated with the provided commitment.
+     */
+    function _getMarketIdForCommitment(address _lenderCommitmentForwarder, uint256 _commitmentId)
+        internal
+        view
+        returns (uint256)
+    {
+        return ILenderCommitmentForwarder(_lenderCommitmentForwarder).getCommitmentMarketId(_commitmentId);
+    }
+
+    /**
+     * @notice Fetches the marketplace fee percentage for a given market ID.
+     * @param _marketId The ID of the market for which to fetch the fee percentage.
+     * @return The marketplace fee percentage for the provided market ID.
+     */
+    function _getMarketFeePct(uint256 _marketId)
+        internal
+        view
+        returns (uint16)
+    {
+        address _marketRegistryAddress = ITellerV2Storage(address(TELLER_V2))
+            .marketRegistry();
+
+        return
+            IMarketRegistry(_marketRegistryAddress).getMarketplaceFee(
+                _marketId
+            );
+    }
+
+  
+}

--- a/packages/contracts/deploy/upgrades/32_upgrade_swap_rollover_g2.ts
+++ b/packages/contracts/deploy/upgrades/32_upgrade_swap_rollover_g2.ts
@@ -1,0 +1,79 @@
+import { DeployFunction } from 'hardhat-deploy/dist/types'
+
+ import { get_ecosystem_contract_address } from "../../helpers/ecosystem-contracts-lookup" 
+
+
+const deployFn: DeployFunction = async (hre) => {
+  hre.log('----------')
+  hre.log('')
+  hre.log('SwapRolloverLoan G2: Proposing upgrade...')
+
+  const networkName = hre.network.name
+
+  const swapRolloverLoan = await hre.contracts.get('SwapRolloverLoan')
+  const tellerV2 = await hre.contracts.get('TellerV2')
+   
+
+    let uniswapV3FactoryAddress =  get_ecosystem_contract_address( hre.network.name, "uniswapV3Factory" ) ;
+   
+   let weth9Address =  get_ecosystem_contract_address( hre.network.name, "weth9" ) ;
+     
+
+
+  await hre.upgrades.proposeBatchTimelock({
+    title: 'Swap Rollover Loan Extension Upgrade',
+    description: ` 
+# SwapRolloverLoan G2 (Extensions Upgrade)
+
+* Upgrades the swap rollover loan contract to work with sushi.
+`,
+    _steps: [
+      {
+        proxy: flashRolloverLoan,
+        implFactory: await hre.ethers.getContractFactory('SwapRolloverLoan'),
+
+        opts: {
+          unsafeAllow: ['constructor', 'state-variable-immutable'],
+          constructorArgs: [
+            await tellerV2.getAddress(),
+         
+                    
+              uniswapV3FactoryAddress,
+              weth9Address,
+          ],
+        },
+      },
+    ],
+  })
+
+  hre.log('done.')
+  hre.log('')
+  hre.log('----------')
+
+  return true
+}
+
+// tags and deployment
+deployFn.id = 'lender-commitment-forwarder:extensions:flash-swap-rollover:g2-upgrade'
+deployFn.tags = [
+  'proposal',
+  'upgrade',
+  'lender-commitment-forwarder',
+  'lender-commitment-forwarder:extensions',
+  'lender-commitment-forwarder:extensions:flash-swap-rollover',
+  'lender-commitment-forwarder:extensions:flash-swap-rollover:g2-upgrade',
+]
+deployFn.dependencies = [
+  'teller-v2:deploy',
+  'lender-commitment-forwarder:staging:deploy',
+  'lender-commitment-forwarder:extensions:flash-swap-rollover:deploy',
+]
+deployFn.skip = async (hre) => {
+  return !(
+    hre.network.live &&
+    [ 'goerli', 'sepolia', 'katana'].includes(
+      hre.network.name
+    )
+  )
+}
+export default deployFn

--- a/packages/contracts/deploy/upgrades/32_upgrade_swap_rollover_g2.ts
+++ b/packages/contracts/deploy/upgrades/32_upgrade_swap_rollover_g2.ts
@@ -29,7 +29,7 @@ const deployFn: DeployFunction = async (hre) => {
 `,
     _steps: [
       {
-        proxy: flashRolloverLoan,
+        proxy: swapRolloverLoan,
         implFactory: await hre.ethers.getContractFactory('SwapRolloverLoan'),
 
         opts: {

--- a/packages/contracts/deployments/katana/.migrations.json
+++ b/packages/contracts/deployments/katana/.migrations.json
@@ -21,5 +21,6 @@
   "default-proxy-admin:transfer": 1753284307,
   "lender-commitment-forwarder:extensions:flash-swap-rollover:deploy": 1754412623,
   "lender-commitment-forwarder:extensions:borrow-swap:deploy": 1754414186,
-  "lender-commitment-group-beacon-v2:pricing-helper": 1754936477
+  "lender-commitment-group-beacon-v2:pricing-helper": 1754936477,
+  "lender-commitment-forwarder:extensions:flash-swap-rollover:g2-upgrade": 1755025963
 }

--- a/packages/contracts/deployments/katana/SwapRolloverLoan.json
+++ b/packages/contracts/deployments/katana/SwapRolloverLoan.json
@@ -509,6 +509,6 @@
     "blockHash": null,
     "blockNumber": null
   },
-  "numDeployments": 1,
+  "numDeployments": 2,
   "implementation": "0xa77517dA5986793C9FAd1638212DbE05E9f5f0c5"
 }

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -11,7 +11,8 @@ out = 'generated/artifacts_forge'
 libs = ['node_modules', 'lib']
 test = 'tests_fork'
 cache_path  = 'generated/cache_forge'
-fork_url = "http://127.0.0.1:8545"
+fs_permissions = [{ access = "read", path = "./deployments" }]
+ 
 
 [doc]
 homepage= "HOME.md"

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -5,6 +5,14 @@ libs = ['node_modules', 'lib']
 test = 'tests'
 cache_path  = 'generated/cache_forge'
 
+[profile.fork]
+src = 'contracts'
+out = 'generated/artifacts_forge'
+libs = ['node_modules', 'lib']
+test = 'tests_fork'
+cache_path  = 'generated/cache_forge'
+fork_url = "http://127.0.0.1:8545"
+
 [doc]
 homepage= "HOME.md"
 ignore = [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "forge": "forge",
     "test": "DISABLE_LOGS=true TS_NODE_TRANSPILE_ONLY=1 TESTING=1 forge test -vvv",
+    
+    "test_forked": "FOUNDRY_PROFILE=fork DISABLE_LOGS=true TS_NODE_TRANSPILE_ONLY=1 TESTING=1  forge test  -vvv",
+
     "coverage": "DISABLE_LOGS=true TS_NODE_TRANSPILE_ONLY=1 TESTING=1 forge coverage --report summary",
     "coverage-report": "forge coverage --report lcov && yarn ts-node scripts/output-branch-coverage-summary.ts",
     "test:cover": "yarn test && yarn coverage",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -6,7 +6,7 @@
     "forge": "forge",
     "test": "DISABLE_LOGS=true TS_NODE_TRANSPILE_ONLY=1 TESTING=1 forge test -vvv",
     
-    "test_forked": "FOUNDRY_PROFILE=fork DISABLE_LOGS=true TS_NODE_TRANSPILE_ONLY=1 TESTING=1  forge test  -vvv",
+    "test_forked": "FOUNDRY_PROFILE=fork DISABLE_LOGS=true TS_NODE_TRANSPILE_ONLY=1 TESTING=1 forge test --rpc-url=http://127.0.0.1:8545 -vvv",
 
     "coverage": "DISABLE_LOGS=true TS_NODE_TRANSPILE_ONLY=1 TESTING=1 forge coverage --report summary",
     "coverage-report": "forge coverage --report lcov && yarn ts-node scripts/output-branch-coverage-summary.ts",

--- a/packages/contracts/tests_fork/FlashSwap_Test.sol
+++ b/packages/contracts/tests_fork/FlashSwap_Test.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Test } from "../tests/util/FoundryTest.sol";
+import "forge-std/console.sol";
+
+  import "forge-std/StdJson.sol";
+
+
+// Import your actual contracts
+import { TellerV2 } from "../contracts/TellerV2.sol";
+import { SwapRolloverLoan } from "../contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan.sol";
+
+contract SwapRollover_Fork_Test is Test {
+
+    string constant NETWORK_NAME = "katana";
+    
+    SwapRolloverLoan swapRolloverLoan;
+    address constant DEPLOYED_SWAP_ROLLOVER_LOAN = 0xa4A8c60Ac9E0c38f8B46316c6B3B508b3BA04415; // Replace with actual deployed address
+        
+
+       using stdJson for string;
+       //put this in a util ?? 
+      function getDeployedAddress(  string memory contractName) internal view returns (address) {
+          string memory root = vm.projectRoot();
+          string memory path = string.concat(root, "/deployments/", NETWORK_NAME, "/", contractName, ".json");
+          string memory json = vm.readFile(path);
+          return json.readAddress(".address");
+      }
+
+      function setUp() public {
+          address payable swapRolloverAddr = payable(getDeployedAddress(  "SwapRolloverLoan"));
+          swapRolloverLoan = SwapRolloverLoan(swapRolloverAddr);
+
+          assertTrue(swapRolloverAddr.code.length > 0, "could not connect to swap rollover loan contract ") ;
+      }
+
+
+ function test_SwapRollover() public   {
+
+
+ }
+    
+    /*
+    function test_TellerV2State() public   {
+        if (address(tellerV2) != address(0)) {
+            // Test reading state from deployed contract
+            try tellerV2.protocolFee() returns (uint16 fee) {
+                console.log("Protocol fee:", fee);
+                assertTrue(fee >= 0, "Fee should be non-negative");
+            } catch {
+                console.log("Failed to read protocol fee");
+            }
+        }
+    }
+    
+    function test_TellerV2Interactions() public {
+        if (address(tellerV2) != address(0)) {
+            // You can test interactions with existing state
+            // For example, check if certain markets exist, etc.
+        }
+    }*/
+}

--- a/packages/contracts/tests_fork/FlashSwap_Test.sol
+++ b/packages/contracts/tests_fork/FlashSwap_Test.sol
@@ -12,13 +12,14 @@ import { TellerV2 } from "../contracts/TellerV2.sol";
 import { SwapRolloverLoan } from "../contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan.sol";
 import { SwapRolloverLoan_G1 } from "../contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan_G1.sol";
 
+import {  MockSwapRolloverLoan } from "../contracts/mock/SwapRolloverLoanMock.sol";
 
 contract SwapRollover_Fork_Test is Test {
 
     string constant NETWORK_NAME = "katana";
     
     SwapRolloverLoan swapRolloverLoan;
-    address constant DEPLOYED_SWAP_ROLLOVER_LOAN = 0xa4A8c60Ac9E0c38f8B46316c6B3B508b3BA04415; // Replace with actual deployed address
+   // address constant DEPLOYED_SWAP_ROLLOVER_LOAN = 0xa4A8c60Ac9E0c38f8B46316c6B3B508b3BA04415; // Replace with actual deployed address
         
 
        using stdJson for string;
@@ -38,7 +39,32 @@ contract SwapRollover_Fork_Test is Test {
       }
 
 
+      function etch_SwapRolloverWithMock() public {
+
+            //all specific to katana ! 
+          address tellerV2Address = 0xf7B14778035fEAF44540A0bC1D4ED859bCB28229;
+          address uniswapFactoryAddress = 0x203e8740894c8955cB8950759876d7E7E45E04c1 ; 
+          address weth9Address = 0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62 ; 
+
+            // Create a mock contract first
+          MockSwapRolloverLoan mockSwapRolloverLoan = new MockSwapRolloverLoan(
+
+                tellerV2Address,
+                uniswapFactoryAddress,
+                weth9Address
+
+            );
+          // Then replace the code at the deployed address
+          vm.etch( address(swapRolloverLoan) , address(mockSwapRolloverLoan).code );
+
+
+      }
+
+
  function test_SwapRollover() public   {
+
+    etch_SwapRolloverWithMock();
+
     // Define test parameters
     address smartCommitmentForwarderAddress = getDeployedAddress("SmartCommitmentForwarder");
     uint256 bidId = 4; // Example loan ID - replace with actual loan ID

--- a/packages/contracts/tests_fork/FlashSwap_Test.sol
+++ b/packages/contracts/tests_fork/FlashSwap_Test.sol
@@ -10,6 +10,8 @@ import "forge-std/console.sol";
 // Import your actual contracts
 import { TellerV2 } from "../contracts/TellerV2.sol";
 import { SwapRolloverLoan } from "../contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan.sol";
+import { SwapRolloverLoan_G1 } from "../contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan_G1.sol";
+
 
 contract SwapRollover_Fork_Test is Test {
 
@@ -37,8 +39,44 @@ contract SwapRollover_Fork_Test is Test {
 
 
  function test_SwapRollover() public   {
-
-
+    // Define test parameters
+    address smartCommitmentForwarderAddress = getDeployedAddress("SmartCommitmentForwarder");
+    uint256 bidId = 4; // Example loan ID - replace with actual loan ID
+    uint256 borrowerAmount = 0; // Additional amount borrower adds
+    
+    // Flash swap parameters
+    SwapRolloverLoan_G1.FlashSwapArgs memory flashSwapArgs = SwapRolloverLoan_G1.FlashSwapArgs({
+        token0: address(0x1e5eFCA3D0dB2c6d5C67a4491845c43253eB9e4e),  
+        token1: address(0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36), 
+        fee: 3000, // 0.3% fee tier
+        flashAmount: 1000, // 1000 tokens
+        borrowToken1: false // Borrow token0 (DAI)
+    });
+    
+    // Accept commitment parameters
+    SwapRolloverLoan_G1.AcceptCommitmentArgs memory acceptCommitmentArgs = SwapRolloverLoan_G1.AcceptCommitmentArgs({
+        commitmentId: 1,
+        smartCommitmentAddress: address(0), // Not using smart commitment
+        principalAmount: 1000,
+        collateralAmount: 1200,
+        collateralTokenId: 0,
+        collateralTokenAddress: address(0x1e5eFCA3D0dB2c6d5C67a4491845c43253eB9e4e), 
+        interestRate: 100, // 10% APR
+        loanDuration: 15000,
+        merkleProof: new bytes32[](0) // No merkle proof
+    });
+    
+    vm.prank(0xbc1d2Ed14128Cd7Af450319b642Fd43d65E495dc);
+    swapRolloverLoan.rolloverLoanWithFlashSwap(
+        smartCommitmentForwarderAddress, 
+        bidId,
+        borrowerAmount,
+        flashSwapArgs,
+        acceptCommitmentArgs 
+    );
+    
+    // Add assertions to verify the rollover worked
+    // assertTrue(someCondition, "Rollover should succeed");
  }
     
     /*

--- a/packages/contracts/tests_fork/ForkTest_Example.sol
+++ b/packages/contracts/tests_fork/ForkTest_Example.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Test } from "../tests/util/FoundryTest.sol";
+import "forge-std/console.sol";
+
+// Import interfaces for contracts you want to interact with
+interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function symbol() external view returns (string memory);
+}
+
+contract ForkTest_Example is Test {
+    
+    function setUp() public {
+        // Fork tests setup - you can add any initialization here
+        console.log("Running fork test on chain:", block.chainid);
+        console.log("Block number:", block.number);
+    }
+    
+    function testForkNetwork() public view {
+        // Basic test to verify we're on the fork
+        console.log("Current block timestamp:", block.timestamp);
+        console.log("Current block number:", block.number);
+        
+        // You can assert specific chain conditions
+        assertTrue(block.number > 0, "Should have valid block number");
+    }
+    
+    function testExistingContract() public {
+        // Example: Test interaction with an existing token contract
+        // Replace with actual contract addresses from Katana network
+        address tokenAddress = 0x1234567890123456789012345678901234567890; // Replace with real address
+        
+        // Only run if the contract exists
+        if (tokenAddress.code.length > 0) {
+            IERC20 token = IERC20(tokenAddress);
+            
+            // Test view functions
+            try token.symbol() returns (string memory symbol) {
+                console.log("Token symbol:", symbol);
+            } catch {
+                console.log("Failed to get symbol");
+            }
+        }
+    }
+    
+    function testWithSpecificAddress() public {
+        // Test interactions with specific addresses that exist on the fork
+        address targetAddress = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266; // Replace with actual address
+        
+        if (targetAddress.balance > 0) {
+            console.log("Address balance:", targetAddress.balance);
+        }
+        
+        // You can impersonate accounts for testing
+        vm.startPrank(targetAddress);
+        // Perform actions as this address
+        vm.stopPrank();
+    }
+}

--- a/packages/contracts/tests_fork/ForkTest_Example.sol
+++ b/packages/contracts/tests_fork/ForkTest_Example.sol
@@ -19,7 +19,7 @@ contract ForkTest_Example is Test {
         console.log("Block number:", block.number);
     }
     
-    function testForkNetwork() public view {
+    function test_ForkNetwork() public   {
         // Basic test to verify we're on the fork
         console.log("Current block timestamp:", block.timestamp);
         console.log("Current block number:", block.number);
@@ -28,7 +28,7 @@ contract ForkTest_Example is Test {
         assertTrue(block.number > 0, "Should have valid block number");
     }
     
-    function testExistingContract() public {
+    function test_ExistingContract() public {
         // Example: Test interaction with an existing token contract
         // Replace with actual contract addresses from Katana network
         address tokenAddress = 0x1234567890123456789012345678901234567890; // Replace with real address
@@ -46,7 +46,7 @@ contract ForkTest_Example is Test {
         }
     }
     
-    function testWithSpecificAddress() public {
+    function test_WithSpecificAddress() public {
         // Test interactions with specific addresses that exist on the fork
         address targetAddress = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266; // Replace with actual address
         

--- a/packages/contracts/tests_fork/TellerV2_Fork_Test.sol
+++ b/packages/contracts/tests_fork/TellerV2_Fork_Test.sol
@@ -8,19 +8,29 @@ import "forge-std/console.sol";
 import { TellerV2 } from "../contracts/TellerV2.sol";
 
 contract TellerV2_Fork_Test is Test {
+
+    /*
+
+            works fine ! 
+     cast code 0xf7B14778035fEAF44540A0bC1D4ED859bCB28229 --rpc-url http://127.0.0.1:8545
+
+
+    */
     
     TellerV2 tellerV2;
-    address constant DEPLOYED_TELLER_ADDRESS = 0x1234567890123456789012345678901234567890; // Replace with actual deployed address
+    address constant DEPLOYED_TELLER_ADDRESS = 0xf7B14778035fEAF44540A0bC1D4ED859bCB28229; // Replace with actual deployed address
     
     function setUp() public {
         // Connect to existing deployed contract on the fork
         if (DEPLOYED_TELLER_ADDRESS.code.length > 0) {
             tellerV2 = TellerV2(DEPLOYED_TELLER_ADDRESS);
             console.log("Connected to TellerV2 at:", DEPLOYED_TELLER_ADDRESS);
+        }else {
+             console.log("Failed to connect to TellerV2 at:", DEPLOYED_TELLER_ADDRESS);
         }
     }
     
-    function testTellerV2State() public view {
+    function test_TellerV2State() public   {
         if (address(tellerV2) != address(0)) {
             // Test reading state from deployed contract
             try tellerV2.protocolFee() returns (uint16 fee) {
@@ -32,7 +42,7 @@ contract TellerV2_Fork_Test is Test {
         }
     }
     
-    function testTellerV2Interactions() public {
+    function test_TellerV2Interactions() public {
         if (address(tellerV2) != address(0)) {
             // You can test interactions with existing state
             // For example, check if certain markets exist, etc.

--- a/packages/contracts/tests_fork/TellerV2_Fork_Test.sol
+++ b/packages/contracts/tests_fork/TellerV2_Fork_Test.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Test } from "../tests/util/FoundryTest.sol";
+import "forge-std/console.sol";
+
+// Import your actual contracts
+import { TellerV2 } from "../contracts/TellerV2.sol";
+
+contract TellerV2_Fork_Test is Test {
+    
+    TellerV2 tellerV2;
+    address constant DEPLOYED_TELLER_ADDRESS = 0x1234567890123456789012345678901234567890; // Replace with actual deployed address
+    
+    function setUp() public {
+        // Connect to existing deployed contract on the fork
+        if (DEPLOYED_TELLER_ADDRESS.code.length > 0) {
+            tellerV2 = TellerV2(DEPLOYED_TELLER_ADDRESS);
+            console.log("Connected to TellerV2 at:", DEPLOYED_TELLER_ADDRESS);
+        }
+    }
+    
+    function testTellerV2State() public view {
+        if (address(tellerV2) != address(0)) {
+            // Test reading state from deployed contract
+            try tellerV2.protocolFee() returns (uint16 fee) {
+                console.log("Protocol fee:", fee);
+                assertTrue(fee >= 0, "Fee should be non-negative");
+            } catch {
+                console.log("Failed to read protocol fee");
+            }
+        }
+    }
+    
+    function testTellerV2Interactions() public {
+        if (address(tellerV2) != address(0)) {
+            // You can test interactions with existing state
+            // For example, check if certain markets exist, etc.
+        }
+    }
+}


### PR DESCRIPTION
Upgrades FlashSwapRollover to work with sushiswap and also adds a testing suite for performing live fork tests with anvil and etch() 