### PR TITLE
Multi Reward Claim with ThirdWeb 

### DIFF
--- a/packages/contracts/.openzeppelin/unknown-8453.json
+++ b/packages/contracts/.openzeppelin/unknown-8453.json
@@ -114,6 +114,11 @@
       "address": "0x48EA70BCe76FE2F0c79B29Bf852a1DCF957982aa",
       "txHash": "0x99bcdd5255ef14b7f295a8517d4e5072f15c8eb8059613fe2990c073902cf638",
       "kind": "transparent"
+    },
+    {
+      "address": "0x588BBC083fe6AB67C18c93BC77974e25eDd23349",
+      "txHash": "0x115a9296400b9500a13e5ef6d34e44c0f4cd558da459f2bf6c1fdf4fa18bd0c0",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -7957,6 +7962,83 @@
           "t_bool": {
             "label": "bool",
             "numberOfBytes": "1"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
+    },
+    "353a621709f9faf1b74aba1fbf9643f15262895f5ab1e638ade3e9ed4bfcd400": {
+      "address": "0x81E108071CDcFF9ec8b9Cf443bF6c5E93a3c3313",
+      "txHash": "0xa0066876c78e109da18e7e228f74a03d0ced19c7e9dc3a0391e0dd72cca684fd",
+      "layout": {
+        "solcVersion": "0.8.11",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
           },
           "t_uint8": {
             "label": "uint8",

--- a/packages/contracts/.openzeppelin/unknown-8453.json
+++ b/packages/contracts/.openzeppelin/unknown-8453.json
@@ -7918,6 +7918,53 @@
         "types": {},
         "namespaces": {}
       }
+    },
+    "85789a4c98323c8244fc8f8fb860862727e647f4c35b41e29c7c3cdefed493cc": {
+      "address": "0xE3BA6B6039E1313A00157f41F017df1d661B76Ec",
+      "txHash": "0x30536ffe36056efda7c410d616d73f670c0739e00d67946311e0c4a9bd5110e1",
+      "layout": {
+        "solcVersion": "0.8.11",
+        "storage": [],
+        "types": {},
+        "namespaces": {}
+      }
+    },
+    "d545cc9d4c2303c27321d4e7a36d80a477c2503c4403883068bc655dd2c2bd9b": {
+      "address": "0x58b8c376cbd6d57df0a5d495079F57b90fc82865",
+      "txHash": "0xc290ff2a8df48f4b22e9b4f64730dafdd3a619f431cf65bba9710252289d3017",
+      "layout": {
+        "solcVersion": "0.8.11",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/packages/contracts/contracts/auxiliary/reward_redeemer.sol
+++ b/packages/contracts/contracts/auxiliary/reward_redeemer.sol
@@ -13,9 +13,10 @@ To combine the two, there could be another function for claimAllAndAutoCompound 
 */
 
 import "../interfaces/auxiliary/IStaking20Upgradeable.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 interface ILenderCommitmentGroupPool {
     function deposit(uint256 assets, address receiver) external returns (uint256 shares);
@@ -25,15 +26,15 @@ interface ILenderCommitmentGroupPool {
 	This contract needs to be set as a trusted forwarder as per EIP2771
 	during init
 */
-contract RewardRedeemer is Initializable {
+contract RewardRedeemer is Initializable, OwnableUpgradeable {
 
-	using Address for address;
+	using AddressUpgradeable for address;
 
 	/**
 	 * @notice Initializes the RewardRedeemer contract
 	 */
 	function initialize() public initializer {
-		// Initialization logic if needed  
+		__Ownable_init();
 	}
 
 	// Events
@@ -95,7 +96,7 @@ contract RewardRedeemer is Initializable {
 			stakingContracts[i] = row.stakingContract;
 			tellerPools[i] = row.tellerPool;
 
-			IERC20 rewardToken = IERC20(row.rewardToken);
+			IERC20Upgradeable rewardToken = IERC20Upgradeable(row.rewardToken);
 
 			// Step 1: Check balance before claiming
 			uint256 balanceBefore = rewardToken.balanceOf(stakerAddress);

--- a/packages/contracts/contracts/auxiliary/reward_redeemer.sol
+++ b/packages/contracts/contracts/auxiliary/reward_redeemer.sol
@@ -15,6 +15,7 @@ To combine the two, there could be another function for claimAllAndAutoCompound 
 import "../interfaces/auxiliary/IStaking20Upgradeable.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 interface ILenderCommitmentGroupPool {
     function deposit(uint256 assets, address receiver) external returns (uint256 shares);
@@ -22,11 +23,18 @@ interface ILenderCommitmentGroupPool {
 
 /*
 	This contract needs to be set as a trusted forwarder as per EIP2771
-	likely with GrantRole
+	during init
 */
-contract RewardRedeemer {
+contract RewardRedeemer is Initializable {
 
 	using Address for address;
+
+	/**
+	 * @notice Initializes the RewardRedeemer contract
+	 */
+	function initialize() public initializer {
+		// Initialization logic if needed  
+	}
 
 	// Events
 	event RewardsClaimed(address indexed user, address[] stakingContracts);

--- a/packages/contracts/contracts/auxiliary/reward_redeemer.sol
+++ b/packages/contracts/contracts/auxiliary/reward_redeemer.sol
@@ -1,0 +1,98 @@
+
+pragma solidity >=0.8.0 <0.9.0;
+
+/*
+
+
+The ThirdWeb staking contracts expose 1 claim per 1 staked pool, but users have many pools and a lot of tokens staked, so it’s just a lot of buttons for them to click
+In order for a user who has ie 10 staked pool tokens, so 10 reward tokens to claim, to only have 1 claim all tx, we’d need an actual solidity function for it. The wallet must be msg.sender for the tx
+The solidity function for claim all rewards would take an array of staking contracts and loop those, calling the claimRewards write function on each. It can also take in the amount the user claims for each.
+Auto-compound would take both a staking contract and a teller pool input. The function would call both claimRewards from the staking contract + call approve + deposit on the teller pool. It can take in both the amount to claim for each, and amount to deposit.
+To combine the two, there could be another function for claimAllAndAutoCompound which does a loop of auto-compound for an array of [staking contracts + teller pools]
+
+*/
+
+
+/*
+		This contract needs to be set as a trusted forwarder as per EIP2771 
+		likely with GrantRole 
+*/
+contract RewardRedeemer {
+
+
+
+	struct AutoCompoundInputRow {
+
+		address stakingContract,
+
+		address tellerPool, 
+ 
+		
+	}
+
+
+
+
+	function claim_multi( 
+
+		address[] stakingContractsArray 
+
+	  ) external  {
+
+
+		address stakerAddress =  msg.sender; 
+
+		// loop through each staking contrat and call claimRewards 
+
+
+		for ( x  in  stakingContractsArray ) {
+
+
+			//need to call this in such a way that the last 20 bytes is the  stakerAddress
+			  
+		          _forwardCall(
+		            abi.encodeWithSelector(
+		                IStaking20.claimRewards.selector 
+		            ),
+		            stakerAddress
+		        );
+
+
+		}
+
+
+
+
+	} 
+
+
+
+
+
+
+
+	function compound_multi( AutoCompoundInputRow[] inputRow  ) external {
+
+
+
+
+
+	}
+
+
+
+	  function _forwardCall(bytes memory _data, address _msgSender)
+        internal
+        returns (bytes memory)
+    {
+        return
+            address(_tellerV2).functionCall(
+                abi.encodePacked(_data, _msgSender)
+            );
+    }
+
+
+
+
+
+}

--- a/packages/contracts/contracts/auxiliary/reward_redeemer.sol
+++ b/packages/contracts/contracts/auxiliary/reward_redeemer.sol
@@ -1,98 +1,144 @@
-
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
 /*
 
 
-The ThirdWeb staking contracts expose 1 claim per 1 staked pool, but users have many pools and a lot of tokens staked, so it’s just a lot of buttons for them to click
-In order for a user who has ie 10 staked pool tokens, so 10 reward tokens to claim, to only have 1 claim all tx, we’d need an actual solidity function for it. The wallet must be msg.sender for the tx
+The ThirdWeb staking contracts expose 1 claim per 1 staked pool, but users have many pools and a lot of tokens staked, so it's just a lot of buttons for them to click
+In order for a user who has ie 10 staked pool tokens, so 10 reward tokens to claim, to only have 1 claim all tx, we'd need an actual solidity function for it. The wallet must be msg.sender for the tx
 The solidity function for claim all rewards would take an array of staking contracts and loop those, calling the claimRewards write function on each. It can also take in the amount the user claims for each.
 Auto-compound would take both a staking contract and a teller pool input. The function would call both claimRewards from the staking contract + call approve + deposit on the teller pool. It can take in both the amount to claim for each, and amount to deposit.
 To combine the two, there could be another function for claimAllAndAutoCompound which does a loop of auto-compound for an array of [staking contracts + teller pools]
 
 */
 
+import "../interfaces/auxiliary/IStaking20Upgradeable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface ILenderCommitmentGroupPool {
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+}
 
 /*
-		This contract needs to be set as a trusted forwarder as per EIP2771 
-		likely with GrantRole 
+	This contract needs to be set as a trusted forwarder as per EIP2771
+	likely with GrantRole
 */
 contract RewardRedeemer {
 
+	using Address for address;
 
+	// Events
+	event RewardsClaimed(address indexed user, address[] stakingContracts);
+	event RewardsCompounded(address indexed user, address[] stakingContracts, address[] tellerPools, uint256[] depositedAmounts);
 
 	struct AutoCompoundInputRow {
-
-		address stakingContract,
-
-		address tellerPool, 
- 
-		
+		address stakingContract;
+		address tellerPool;
+		address rewardToken;
 	}
 
+	/**
+	 * @notice Claims rewards from multiple staking contracts in a single transaction
+	 * @param stakingContractsArray Array of staking contract addresses to claim rewards from
+	 */
+	function claim_multi(
+		address[] calldata stakingContractsArray
+	) external {
 
+		address stakerAddress = msg.sender;
 
+		// Loop through each staking contract and call claimRewards
+		for (uint256 i = 0; i < stakingContractsArray.length; i++) {
+			address stakingContract = stakingContractsArray[i];
 
-	function claim_multi( 
-
-		address[] stakingContractsArray 
-
-	  ) external  {
-
-
-		address stakerAddress =  msg.sender; 
-
-		// loop through each staking contrat and call claimRewards 
-
-
-		for ( x  in  stakingContractsArray ) {
-
-
-			//need to call this in such a way that the last 20 bytes is the  stakerAddress
-			  
-		          _forwardCall(
-		            abi.encodeWithSelector(
-		                IStaking20.claimRewards.selector 
-		            ),
-		            stakerAddress
-		        );
-
-
+			// Call claimRewards on the staking contract using EIP-2771 forwarding
+			// The staking contract must trust this contract as a forwarder
+			_forwardCall(
+				stakingContract,
+				abi.encodeWithSelector(
+					IStaking20.claimRewards.selector
+				),
+				stakerAddress
+			);
 		}
 
-
-
-
-	} 
-
-
-
-
-
-
-
-	function compound_multi( AutoCompoundInputRow[] inputRow  ) external {
-
-
-
-
-
+		emit RewardsClaimed(stakerAddress, stakingContractsArray);
 	}
 
+	/**
+	 * @notice Claims rewards and automatically compounds them by depositing into Teller pools
+	 * @param inputRows Array of compound instructions containing staking contract, pool, and reward token info
+	 */
+	function compound_multi(
+		AutoCompoundInputRow[] calldata inputRows
+	) external {
 
+		address stakerAddress = msg.sender;
 
-	  function _forwardCall(bytes memory _data, address _msgSender)
-        internal
-        returns (bytes memory)
-    {
-        return
-            address(_tellerV2).functionCall(
-                abi.encodePacked(_data, _msgSender)
-            );
-    }
+		address[] memory stakingContracts = new address[](inputRows.length);
+		address[] memory tellerPools = new address[](inputRows.length);
+		uint256[] memory depositedAmounts = new uint256[](inputRows.length);
 
+		// Loop through each compound instruction
+		for (uint256 i = 0; i < inputRows.length; i++) {
+			AutoCompoundInputRow calldata row = inputRows[i];
 
+			stakingContracts[i] = row.stakingContract;
+			tellerPools[i] = row.tellerPool;
 
+			IERC20 rewardToken = IERC20(row.rewardToken);
 
+			// Step 1: Check balance before claiming
+			uint256 balanceBefore = rewardToken.balanceOf(stakerAddress);
 
+			// Step 2: Claim rewards from the staking contract
+			_forwardCall(
+				row.stakingContract,
+				abi.encodeWithSelector(
+					IStaking20.claimRewards.selector
+				),
+				stakerAddress
+			);
+
+			// Step 3: Check balance after claiming to determine amount received
+			uint256 balanceAfter = rewardToken.balanceOf(stakerAddress);
+			uint256 claimedAmount = balanceAfter - balanceBefore;
+			depositedAmounts[i] = claimedAmount;
+
+			// Only proceed if we actually claimed some rewards
+			if (claimedAmount > 0) {
+				// Step 4: Transfer reward tokens from user to this contract
+				rewardToken.transferFrom(stakerAddress, address(this), claimedAmount);
+
+				// Step 5: Approve the teller pool to spend the reward tokens
+				rewardToken.approve(row.tellerPool, claimedAmount);
+
+				// Step 6: Deposit the reward tokens into the teller pool
+				ILenderCommitmentGroupPool(row.tellerPool).deposit(
+					claimedAmount,
+					stakerAddress
+				);
+			}
+		}
+
+		emit RewardsCompounded(stakerAddress, stakingContracts, tellerPools, depositedAmounts);
+	}
+
+	/**
+	 * @dev Internal function to forward calls using EIP-2771 meta-transaction format
+	 * @param target The contract address to call
+	 * @param data The encoded function call data
+	 * @param msgSender The address that should be treated as the msg.sender
+	 */
+	function _forwardCall(
+		address target,
+		bytes memory data,
+		address msgSender
+	) internal returns (bytes memory) {
+		// Append the msgSender address to the calldata for EIP-2771 compatibility
+		return target.functionCall(
+			abi.encodePacked(data, msgSender)
+		);
+	}
 }

--- a/packages/contracts/contracts/auxiliary/reward_redeemer.sol
+++ b/packages/contracts/contracts/auxiliary/reward_redeemer.sol
@@ -110,6 +110,8 @@ contract RewardRedeemer is Initializable, OwnableUpgradeable {
 				stakerAddress
 			);
 
+
+/* 
 			// Step 3: Check balance after claiming to determine amount received
 			uint256 balanceAfter = rewardToken.balanceOf(stakerAddress);
 			uint256 claimedAmount = balanceAfter - balanceBefore;
@@ -129,6 +131,10 @@ contract RewardRedeemer is Initializable, OwnableUpgradeable {
 					stakerAddress
 				);
 			}
+
+			*/ 
+
+			
 		}
 
 		emit RewardsCompounded(stakerAddress, stakingContracts, tellerPools, depositedAmounts);

--- a/packages/contracts/contracts/interfaces/auxiliary/IStaking20Upgradeable.sol
+++ b/packages/contracts/contracts/interfaces/auxiliary/IStaking20Upgradeable.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.9.0;
+
+/// @author thirdweb
+
+interface IStaking20 {
+    /// @dev Emitted when tokens are staked.
+    event TokensStaked(address indexed staker, uint256 amount);
+
+    /// @dev Emitted when a tokens are withdrawn.
+    event TokensWithdrawn(address indexed staker, uint256 amount);
+
+    /// @dev Emitted when a staker claims staking rewards.
+    event RewardsClaimed(address indexed staker, uint256 rewardAmount);
+
+    /// @dev Emitted when contract admin updates timeUnit.
+    event UpdatedTimeUnit(uint256 oldTimeUnit, uint256 newTimeUnit);
+
+    /// @dev Emitted when contract admin updates rewardsPerUnitTime.
+    event UpdatedRewardRatio(
+        uint256 oldNumerator,
+        uint256 newNumerator,
+        uint256 oldDenominator,
+        uint256 newDenominator
+    );
+
+    /// @dev Emitted when contract admin updates minimum staking amount.
+    event UpdatedMinStakeAmount(uint256 oldAmount, uint256 newAmount);
+
+    /**
+     *  @notice Staker Info.
+     *
+     *  @param amountStaked             Total number of tokens staked by the staker.
+     *
+     *  @param timeOfLastUpdate         Last reward-update timestamp.
+     *
+     *  @param unclaimedRewards         Rewards accumulated but not claimed by user yet.
+     *
+     *  @param conditionIdOflastUpdate  Condition-Id when rewards were last updated for user.
+     */
+    struct Staker {
+        uint128 timeOfLastUpdate;
+        uint64 conditionIdOflastUpdate;
+        uint256 amountStaked;
+        uint256 unclaimedRewards;
+    }
+
+    /**
+     *  @notice Staking Condition.
+     *
+     *  @param timeUnit                 Unit of time specified in number of seconds. Can be set as 1 seconds, 1 days, 1 hours, etc.
+     *
+     *  @param rewardRatioNumerator     Rewards ratio is the number of reward tokens for a number of staked tokens,
+     *                                  per unit of time.
+     *
+     *  @param rewardRatioDenominator   Rewards ratio is the number of reward tokens for a number of staked tokens,
+     *                                  per unit of time.
+     *
+     *  @param startTimestamp           Condition start timestamp.
+     *
+     *  @param endTimestamp             Condition end timestamp.
+     */
+    struct StakingCondition {
+        uint80 timeUnit;
+        uint80 startTimestamp;
+        uint80 endTimestamp;
+        uint256 rewardRatioNumerator;
+        uint256 rewardRatioDenominator;
+    }
+
+    /**
+     *  @notice Stake ERC721 Tokens.
+     *
+     *  @param amount    Amount to stake.
+     */
+    function stake(uint256 amount) external payable;
+
+    /**
+     *  @notice Withdraw staked tokens.
+     *
+     *  @param amount    Amount to withdraw.
+     */
+    function withdraw(uint256 amount) external;
+
+    /**
+     *  @notice Claim accumulated rewards.
+     *
+     */
+    function claimRewards() external;
+
+    /**
+     *  @notice View amount staked and total rewards for a user.
+     *
+     *  @param staker    Address for which to calculated rewards.
+     */
+    function getStakeInfo(address staker) external view returns (uint256 _tokensStaked, uint256 _rewards);
+}

--- a/packages/contracts/contracts/interfaces/auxiliary/IStaking20Upgradeable.sol
+++ b/packages/contracts/contracts/interfaces/auxiliary/IStaking20Upgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.9.0;
+pragma solidity ^0.8.0;
 
 /// @author thirdweb
 

--- a/packages/contracts/contracts/mock/TellerV2SolMock.sol
+++ b/packages/contracts/contracts/mock/TellerV2SolMock.sol
@@ -126,7 +126,7 @@ ILoanRepaymentCallbacks
         address _receiver,
         Collateral[] calldata _collateralInfo
     ) public returns (uint256 bidId_) {
-        submitBid(
+        return submitBid(
             _lendingToken,
             _marketplaceId,
             _principal,

--- a/packages/contracts/contracts/mock/UniswapPricingHelperMock.sol
+++ b/packages/contracts/contracts/mock/UniswapPricingHelperMock.sol
@@ -2,7 +2,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // SPDX-License-Identifier: MIT
 
 
-import "forge-std/console.sol";
+// import "forge-std/console.sol";
  
 
 import {IUniswapPricingLibrary} from "../interfaces/IUniswapPricingLibrary.sol";

--- a/packages/contracts/contracts/price_oracles/UniswapPricingHelper.sol
+++ b/packages/contracts/contracts/price_oracles/UniswapPricingHelper.sol
@@ -2,7 +2,7 @@ pragma solidity >=0.8.0 <0.9.0;
 // SPDX-License-Identifier: MIT
 
 
-import "forge-std/console.sol";
+// import "forge-std/console.sol";
  
 
 import {IUniswapPricingLibrary} from "../interfaces/IUniswapPricingLibrary.sol";
@@ -51,10 +51,6 @@ contract UniswapPricingHelper
                 poolRoutes[1]
             );
 
-
-            console.log("ratio");
-            console.logUint(pool0PriceRatio);
-            console.logUint(pool1PriceRatio);
 
             return
                 FullMath.mulDiv(

--- a/packages/contracts/deploy/auxiliary/reward_redeemer.ts
+++ b/packages/contracts/deploy/auxiliary/reward_redeemer.ts
@@ -1,0 +1,22 @@
+import { DeployFunction } from 'hardhat-deploy/dist/types'
+
+const deployFn: DeployFunction = async (hre) => {
+  const rewardRedeemer = await hre.deployProxy(
+    'RewardRedeemer',
+    {
+      initializer: 'initialize',
+      initArgs: [],
+      unsafeAllow: ['constructor', 'state-variable-immutable'],
+    }
+  )
+
+  return true
+}
+
+// tags and deployment
+deployFn.id = 'reward-redeemer:deploy'
+deployFn.tags = ['reward-redeemer:deploy']
+deployFn.dependencies = [
+   
+]
+export default deployFn

--- a/packages/contracts/deployments/base/.migrations.json
+++ b/packages/contracts/deployments/base/.migrations.json
@@ -42,5 +42,6 @@
   "uniswap-pricing-helper:deploy": 1755183533,
   "lender-commitment-group-beacon-v2:pricing-helper": 1755183533,
   "lender-commitment-forwarder:extensions:flash-swap-rollover:g2-upgrade": 1755270789,
-  "timelock-controller:update-delay-7200": 1757524216
+  "timelock-controller:update-delay-7200": 1757524216,
+  "reward-redeemer:deploy": 1762274727
 }

--- a/packages/contracts/deployments/base/RewardRedeemer.json
+++ b/packages/contracts/deployments/base/RewardRedeemer.json
@@ -1,0 +1,166 @@
+{
+  "address": "0x588BBC083fe6AB67C18c93BC77974e25eDd23349",
+  "abi": [
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "Initialized",
+      "inputs": [
+        {
+          "type": "uint8",
+          "name": "version",
+          "indexed": false
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "OwnershipTransferred",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "previousOwner",
+          "indexed": true
+        },
+        {
+          "type": "address",
+          "name": "newOwner",
+          "indexed": true
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "RewardsClaimed",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "user",
+          "indexed": true
+        },
+        {
+          "type": "address[]",
+          "name": "stakingContracts"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "anonymous": false,
+      "name": "RewardsCompounded",
+      "inputs": [
+        {
+          "type": "address",
+          "name": "user",
+          "indexed": true
+        },
+        {
+          "type": "address[]",
+          "name": "stakingContracts"
+        },
+        {
+          "type": "address[]",
+          "name": "tellerPools"
+        },
+        {
+          "type": "uint256[]",
+          "name": "depositedAmounts"
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "claim_multi",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address[]",
+          "name": "stakingContractsArray"
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "compound_multi",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "tuple[]",
+          "name": "inputRows",
+          "components": [
+            {
+              "type": "address",
+              "name": "stakingContract"
+            },
+            {
+              "type": "address",
+              "name": "tellerPool"
+            },
+            {
+              "type": "address",
+              "name": "rewardToken"
+            }
+          ]
+        }
+      ],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "constant": false,
+      "payable": false,
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "owner",
+      "constant": true,
+      "stateMutability": "view",
+      "payable": false,
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "address",
+          "name": ""
+        }
+      ]
+    },
+    {
+      "type": "function",
+      "name": "renounceOwnership",
+      "constant": false,
+      "payable": false,
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "type": "function",
+      "name": "transferOwnership",
+      "constant": false,
+      "payable": false,
+      "inputs": [
+        {
+          "type": "address",
+          "name": "newOwner"
+        }
+      ],
+      "outputs": []
+    }
+  ],
+  "transactionHash": "0x115a9296400b9500a13e5ef6d34e44c0f4cd558da459f2bf6c1fdf4fa18bd0c0",
+  "receipt": {
+    "to": null,
+    "from": "0xD9B023522CeCe02251d877bb0EB4f06fDe6F98E6",
+    "blockHash": null,
+    "blockNumber": null
+  },
+  "numDeployments": 1,
+  "implementation": "0x81E108071CDcFF9ec8b9Cf443bF6c5E93a3c3313"
+}

--- a/packages/contracts/remappings.txt
+++ b/packages/contracts/remappings.txt
@@ -1,0 +1,3 @@
+forge-std/=lib/forge-std/src/
+@openzeppelin/=node_modules/@openzeppelin/
+@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/

--- a/packages/contracts/tests/LenderCommitmentForwarder/extensions/FlashRolloverLoan/SwapRolloverLoan_G2_Unit_Test.sol
+++ b/packages/contracts/tests/LenderCommitmentForwarder/extensions/FlashRolloverLoan/SwapRolloverLoan_G2_Unit_Test.sol
@@ -161,6 +161,9 @@ contract SwapRolloverLoan_Unit_Test is Testable {
 
 
 
+        collateralToken.deposit{ value: 100e18 }();
+        collateralToken.transfer( address(borrower ), 5e18 ); 
+
         ILenderCommitmentGroup_V2.CommitmentGroupConfig memory commitmentGroupConfig = ILenderCommitmentGroup_V2.CommitmentGroupConfig({
             principalTokenAddress: address(wethMock) ,
             collateralTokenAddress: address(collateralToken),
@@ -350,7 +353,7 @@ contract SwapRolloverLoan_Unit_Test is Testable {
                 commitmentId: 0,
                 smartCommitmentAddress: address(  tellerPool   ),
                 principalAmount: principalAmount,
-                collateralAmount: 100,
+                collateralAmount: 100000000000,
                 collateralTokenId: 0,
                 collateralTokenAddress: address( collateralToken  ),
                 interestRate: interestRate,
@@ -368,6 +371,10 @@ contract SwapRolloverLoan_Unit_Test is Testable {
                 borrowToken1: false 
              //   poolAddress: address( uniswapPoolMock )
             });
+
+
+
+        // give borrow lots of collateralToken
 
         vm.prank(address(borrower));
         uint256 loanId = tellerV2.submitBid(
@@ -392,8 +399,7 @@ contract SwapRolloverLoan_Unit_Test is Testable {
             address( smartCommitmentForwarder  ),
             loanId, 
             borrowerAmount,
-           // rewardAmount,
-        //    rewardRecipient, 
+            
 
             flashSwapArgs,
             commitmentArgs

--- a/packages/contracts/tests_fork/MultiClaim_Test.sol
+++ b/packages/contracts/tests_fork/MultiClaim_Test.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Test } from "../tests/util/FoundryTest.sol";
+import "forge-std/console.sol";
+import "forge-std/StdJson.sol";
+
+
+// Import your actual contracts
+import { TellerV2 } from "../contracts/TellerV2.sol";
+import { SwapRolloverLoan } from "../contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan.sol";
+import { SwapRolloverLoan_G1 } from "../contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan_G1.sol";
+import { SwapRolloverLoan_G2 } from "../contracts/LenderCommitmentForwarder/extensions/rollover/SwapRolloverLoan_G2.sol";
+
+import {  MockSwapRolloverLoan } from "../contracts/mock/SwapRolloverLoanMock.sol";
+import { LenderCommitmentGroupFactory_V2 } from "../contracts/LenderCommitmentForwarder/extensions/LenderCommitmentGroup/LenderCommitmentGroup_Factory_V2.sol";
+import { ILenderCommitmentGroup_V2 } from "../contracts/interfaces/ILenderCommitmentGroup_V2.sol";
+
+ 
+
+import { UniswapPricingHelper } from "../contracts/price_oracles/UniswapPricingHelper.sol";
+
+import { IUniswapPricingLibrary } from "../contracts/interfaces/IUniswapPricingLibrary.sol";
+
+import { LenderCommitmentGroup_Pool_V2 } from "../contracts/LenderCommitmentForwarder/extensions/LenderCommitmentGroup/LenderCommitmentGroup_Pool_V2.sol";
+import { SmartCommitmentForwarder } from "../contracts/LenderCommitmentForwarder/SmartCommitmentForwarder.sol";
+
+import { RewardRedeemer } from "../contracts/auxiliary/reward_redeemer.sol";
+
+
+/*
+
+ 
+
+*/
+
+// https://dashboard.tenderly.co/teller/v2/simulator/new?block=36790450&from=0xbc1d2Ed14128Cd7Af450319b642Fd43d65E495dc&contractAddress=0x5cfD3aeD08a444Be32839bD911Ebecd688861164&rawFunctionInput=0x8288da8a000000000000000000000000000000000000000000000000000000000000060c&network=8453&blockIndex=0&gas=8000000&gasPrice=0&value=0&headerBlockNumber=&headerTimestamp=
+
+contract MultiClaim_Fork_Test is Test {
+
+    
+
+      RewardRedeemer rewardRedeemer;
+
+   
+        
+      using stdJson for string;
+        
+      function getDeployedAddress(  string memory contractName, string memory networkName ) internal view returns (address) {
+          string memory root = vm.projectRoot();
+          string memory path = string.concat(root, "/deployments/", networkName, "/", contractName, ".json");
+          string memory json = vm.readFile(path);
+          return json.readAddress(".address");
+      }
+
+  
+
+     function test_claim_multi() public   {
+
+        rewardRedeemer = RewardRedeemer( getDeployedAddress( "RewardRedeemer", "base" ) );
+
+
+        address[] memory stakingContracts = new address[](1);
+
+        stakingContracts[0] = 0xE9A11045dB982fc0975123Fa09c59BBb48ac2374; 
+ 
+
+        vm.prank(0xD9B023522CeCe02251d877bb0EB4f06fDe6F98E6);  //andres wallet
+          rewardRedeemer.claim_multi(
+              stakingContracts
+        );
+ 
+     }
+
+
+ 
+ 
+}

--- a/packages/contracts/tests_fork/MultiClaim_Test.sol
+++ b/packages/contracts/tests_fork/MultiClaim_Test.sol
@@ -73,6 +73,33 @@ contract MultiClaim_Fork_Test is Test {
      }
 
 
+
+
+     function test_compound_multi() public   {
+
+        rewardRedeemer = RewardRedeemer( getDeployedAddress( "RewardRedeemer", "base" ) );
+
+        // Create AutoCompoundInputRow array
+        RewardRedeemer.AutoCompoundInputRow[] memory autoCompoundInputRows =
+            new RewardRedeemer.AutoCompoundInputRow[](1);
+
+        // Configure the compound instruction
+        // Staking contract: ThirdWeb staking contract
+        // Teller pool: Compound pool (USDC) 
+        autoCompoundInputRows[0] = RewardRedeemer.AutoCompoundInputRow(
+            0xE9A11045dB982fc0975123Fa09c59BBb48ac2374,  // stakingContract
+            0x32a2019490E14677b9260Ebe00a6A6E0C3582F93,  // tellerPool (Compound pool)
+            0x1111111111166b7FE7bd91427724B487980aFc69   // rewardToken (Zora on Base)
+        );
+
+        vm.prank(0xD9B023522CeCe02251d877bb0EB4f06fDe6F98E6);  //andres wallet
+          rewardRedeemer.compound_multi(
+              autoCompoundInputRows
+        );
+
+     }
+
+
  
  
 }


### PR DESCRIPTION
Adds the reward_redeemer.sol smart contract which allows users to claim rewards for multiple thirdweb pools in a single transaction.  It also allows users to re-stake rewards into their respective pools in a single transaction (multiple at a time.)  